### PR TITLE
Notify hub of failed calls

### DIFF
--- a/broker/src/session/session.erl
+++ b/broker/src/session/session.erl
@@ -277,7 +277,7 @@ in_progress({hibernate, NewSession, Ptr}, _From, State = #state{session = _Sessi
 
 notify_status(Status, Session) ->
   notify_status_to_callback_url(Status, Session),
-  notify_status_to_hub(Status, Session).
+  notify_status_to_hub_if_enabled(Status, Session).
 
 notify_status_to_callback_url(Status, Session = #session{call_log = CallLog, address = Address, callback_params = CallbackParams, started_at = StartedAt}) ->
   case Session#session.status_callback_url of
@@ -305,7 +305,7 @@ notify_status_to_callback_url(Status, Session = #session{call_log = CallLog, add
       end)
   end.
 
-notify_status_to_hub(Status, Session = #session{call_log = CallLog, js_context = JS, project = Project}) ->
+notify_status_to_hub_if_enabled(Status, Session = #session{call_log = CallLog, js_context = JS, project = Project}) ->
   case Status of
     completed ->
       HubEnabled = application:get_env(verboice, hub_enabled, false),

--- a/spec/models/jobs/hub_job_spec.rb
+++ b/spec/models/jobs/hub_job_spec.rb
@@ -7,12 +7,42 @@ describe Jobs::HubJob do
     base_url = HubClient.current.config.url
     connector_guid = HubClient.current.config.connector_guid
 
-    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_finished").
-         with(:body => "{\"project_id\":1,\"call_flow_id\":2}",
+    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_done").
+         with(:body => "{\"project_id\":1,\"call_flow_id\":2,\"status\":\"completed\"}",
               :headers => {'Content-Type'=>'application/json'}).
          to_return(:status => 200, :body => "", :headers => {})
 
-    job = Jobs::HubJob.new(project_id: 1, call_flow_id: 2)
+    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_finished").
+         with(:body => "{\"project_id\":1,\"call_flow_id\":2,\"status\":\"completed\"}",
+              :headers => {'Content-Type'=>'application/json'}).
+         to_return(:status => 200, :body => "", :headers => {})
+
+    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_completed").
+         with(:body => "{\"project_id\":1,\"call_flow_id\":2,\"status\":\"completed\"}",
+              :headers => {'Content-Type'=>'application/json'}).
+         to_return(:status => 200, :body => "", :headers => {})
+
+    job = Jobs::HubJob.new(project_id: 1, call_flow_id: 2, status: :completed)
+    job.perform
+  end
+
+  it "posts failed results to hub" do
+    HubClient.current "token" => "some_token"
+
+    base_url = HubClient.current.config.url
+    connector_guid = HubClient.current.config.connector_guid
+
+    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_done").
+         with(:body => "{\"project_id\":1,\"call_flow_id\":2,\"status\":\"failed\"}",
+              :headers => {'Content-Type'=>'application/json'}).
+         to_return(:status => 200, :body => "", :headers => {})
+
+    stub_request(:post, "#{base_url}/api/notify/connectors/#{connector_guid}/projects/1/call_flows/2/$events/call_failed").
+         with(:body => "{\"project_id\":1,\"call_flow_id\":2,\"status\":\"failed\"}",
+              :headers => {'Content-Type'=>'application/json'}).
+         to_return(:status => 200, :body => "", :headers => {})
+
+    job = Jobs::HubJob.new(project_id: 1, call_flow_id: 2, status: :failed)
     job.perform
   end
 end


### PR DESCRIPTION
I've kept `call_finished` for backwards compatibility, and added `call_done` for every call, `call_completed` for successful calls and `call_failed` for failures.

`completed` and `failed` are Verboice's own terminology, so it made sense.

Fixes #686
Depends on instedd/hub#138 being merged
