### PR TITLE
Config switch to skip user account confirmation on sign up

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -18,8 +18,12 @@
 class Account < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable, :lockable and :timeoutable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :confirmable, :omniauthable
+  DEVISE_MODULES = [:database_authenticatable, :registerable,
+                    :recoverable, :rememberable, :trackable, :validatable, :omniauthable]
+  DEVISE_CONFIRMABLE = Rails.configuration.verboice_configuration[:skip_account_confirmation] \
+                        ? [] : [:confirmable]
+
+  devise *(DEVISE_MODULES + DEVISE_CONFIRMABLE)
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -24,7 +24,7 @@ en:
       send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
-      signed_up: 'You have signed up successfully. If enabled, a confirmation was sent to your e-mail.'
+      signed_up: 'You have signed up successfully.'
       updated: 'You updated your account successfully.'
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
     unlocks:

--- a/config/verboice.yml
+++ b/config/verboice.yml
@@ -1,6 +1,7 @@
 broker_port: 9999
 ispeech_format: mp3
 asset_host: "http://default-domain.com"
+skip_account_confirmation: false
 default_url_options:
   host: "default-domain.com"
   protocol: "http"


### PR DESCRIPTION
On local installations, it does not make sense to require a user (typically a single user) to confirm his/her account. Furthermore, email delivery might not be configured in these installations.

Fixes #745