### PR TITLE
Prevent browser autocomplete of non-login password fields

### DIFF
--- a/app/views/call_flows/_form.html.haml
+++ b/app/views/call_flows/_form.html.haml
@@ -25,7 +25,7 @@
     %br/
     = f.label :callback_url_password, 'Password'
     %br/
-    = f.password_field :callback_url_password, :class => "w30"
+    = f.password_field :callback_url_password, :class => "w30", autocomplete: 'new-password', value: call_flow.callback_url_password
 
   - if OAuth2::Client.service_configured?(:google) && !call_flow.new_record?
     %hr

--- a/app/views/channels/_form_custom_sip.haml
+++ b/app/views/channels/_form_custom_sip.haml
@@ -3,7 +3,7 @@
   = f.text_field :username, :autocomplete => 'off', readonly: readonly
 .field
   = f.label :password
-  = f.password_field :password, :value => @channel.password, :autocomplete => 'off', readonly: readonly
+  = f.password_field :password, :value => @channel.password, :autocomplete => 'new-password', readonly: readonly
 .field
   = f.label :number
   = f.text_field :number, readonly: readonly

--- a/app/views/channels/_form_sip_server.haml
+++ b/app/views/channels/_form_sip_server.haml
@@ -4,7 +4,7 @@
     %input{type: 'text', readonly: 'true', value: "verboice_#{@channel.id}"}
 .field
   = f.label :password
-  = f.password_field :password, :value => @channel.password, :autocomplete => 'off', readonly: readonly
+  = f.password_field :password, :value => @channel.password, :autocomplete => 'new-password', readonly: readonly
 .field
   = f.label :number
   = f.text_field :number, readonly: readonly

--- a/app/views/channels/_form_template_based_sip.html.haml
+++ b/app/views/channels/_form_template_based_sip.html.haml
@@ -3,7 +3,7 @@
   = f.text_field :username, :autocomplete => 'off', readonly: readonly
 .field
   = f.label :password
-  = f.password_field :password, :value => @channel.config['password'], :autocomplete => 'off', readonly: readonly
+  = f.password_field :password, :value => @channel.config['password'], :autocomplete => 'new-password', readonly: readonly
 .field
   = f.label :number
   = f.text_field :number, readonly: readonly

--- a/app/views/projects/_form.haml
+++ b/app/views/projects/_form.haml
@@ -65,7 +65,7 @@
 
   = f.text_field :status_callback_url, :label => 'URL', readonly: readonly
   = f.text_field :status_callback_url_user, :label => 'User', :autocomplete => 'off', readonly: readonly
-  = f.password_field :status_callback_url_password, :label => 'Password', :autocomplete => 'off', readonly: readonly
+  = f.password_field :status_callback_url_password, :label => 'Password', :value => @project.status_callback_url_password, :autocomplete => 'new-password', readonly: readonly
   = f.label :status_callback_include_vars, "Include session variables in query string", style: 'display:inline-block'
   = f.check_box :status_callback_include_vars
 


### PR DESCRIPTION
User and password fields for channels and callbacks were being autocompleted with
the current user and pass. According to [1], browsers now ignore autocomplete off
in password fields, having to use new-password instead, to indicate that the
password is different from the site's.

Also, the password value was not being re-loaded, so any edit on the form (without
re-entering the password) ended up in the password value being cleared. Though
the correct way to fix this would be adding an option to "click here if you want
to change the password" and only render the control in that case, re-sending the
password back to the client does the trick for now.

Tested on Chrome 53, Firefox 47 and Safari 9.1.3

Fixes #717

[1]: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Conflicts:
	app/views/projects/_form.haml