### PR TITLE
Show contact last activity in phonebook

### DIFF
--- a/app/models/call_log.rb
+++ b/app/models/call_log.rb
@@ -84,6 +84,8 @@ class CallLog < ActiveRecord::Base
     self.finished_at = Time.now.utc
     self.save!
 
+    self.contact.update_column(:last_activity_at, self.finished_at) if self.contact && self.finished_at > self.contact.finished_at
+
     begin
       call_flow.try(:push_results, self) if call_flow && call_flow.store_in_fusion_tables
     rescue Exception => ex

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -24,6 +24,7 @@ class Contact < ActiveRecord::Base
   has_many :contact_scheduled_calls, :dependent => :destroy
   has_many :impersonate_original_records, :class_name => 'ImpersonateRecord', :foreign_key => 'contact_id', :dependent => :destroy
   has_many :impersonate_impersonated_records, :class_name => 'ImpersonateRecord', :foreign_key => 'impersonated_id', :dependent => :destroy
+  has_many :call_logs
 
   accepts_nested_attributes_for :persisted_variables,
     :reject_if => lambda { |attributes| attributes[:value].blank? || (attributes[:project_variable_id].blank? && attributes[:implicit_key].blank?) },
@@ -41,7 +42,7 @@ class Contact < ActiveRecord::Base
 
   def next_address(address)
     addresses = self.addresses.order(:id).map(&:address)
-    addresses.drop_while { |addr| addr != address }.second 
+    addresses.drop_while { |addr| addr != address }.second
   end
 
   def semicolon_separated_addresses

--- a/app/models/contacts_finder.rb
+++ b/app/models/contacts_finder.rb
@@ -96,7 +96,9 @@ private
        "LEFT JOIN persisted_variables AS sorting_var ON sorting_var.contact_id = contacts.id AND sorting_var.implicit_key = '#{implicit_key}'"]
     elsif options[:address]
       ["sorting_address.first_address",
-       "LEFT JOIN (SELECT contact_id, COALESCE(address) as first_address FROM contact_addresses WHERE project_id = #{@project.id} GROUP BY contact_id ORDER BY id) AS sorting_address ON sorting_address.contact_id = contacts.id"]
+       "LEFT JOIN (SELECT contact_id, COALESCE(address) as first_address FROM contact_addresses WHERE project_id = #{@project.id} GROUP BY contact_id ORDER BY contact_addresses.id) AS sorting_address ON sorting_address.contact_id = contacts.id"]
+    elsif options[:last_activity]
+      ["contacts.last_activity_at", nil]
     end
   end
 

--- a/app/views/contacts/_list.html.haml
+++ b/app/views/contacts/_list.html.haml
@@ -4,6 +4,9 @@
       %th.sort{colspan: 2, data: {"sort-key" => true, "sort-type" => "address"}, class: ((params[:sort_type].try(&:to_s) == 'address') ? params[:sort_dir] || 'up' : nil)}
         Phone numbers
         %span
+      %th.sort{data: {"sort-key" => true, "sort-type" => "last_activity"}, class: ((params[:sort_type].try(&:to_s) == 'last_activity') ? params[:sort_dir] || 'up' : nil)}
+        Last activity
+        %span
       - @implicit_variables.each do |variable|
         %th.sort{data: {"sort-key" => variable.key, "sort-type" => "implicit_key"}, class: ((params[:sort_key] == variable.key) ? params[:sort_dir] || 'up' : nil)}
           =variable.key
@@ -22,6 +25,7 @@
         %td.right
           - if project_admin?
             = link_to '', project_contact_path(@project, contact), :confirm => 'Are you sure?', :method => :delete, :class => 'button premove'
+        %td= raw time_ago contact.last_activity_at
         - @implicit_variables.each do |implicit_variable|
           - variable = contact.persisted_variables.detect{|v| v.implicit_key == implicit_variable.key}
           %td= variable.try(:value)

--- a/broker/include/db.hrl
+++ b/broker/include/db.hrl
@@ -3,7 +3,7 @@
 -record(call_log, {id, account_id, project_id, finished_at, direction, address, state, created_at, updated_at, channel_id, started_at, schedule_id, not_before, call_flow_id, pbx_logs_guid, fail_reason, contact_id, fail_code, fail_details}).
 -record(call_log_entry, {id, call_id, severity, details, created_at, updated_at}).
 -record(channel, {id, account_id, call_flow_id, name, config, type, created_at, updated_at}).
--record(contact, {id, project_id, anonymous, created_at, updated_at}).
+-record(contact, {id, project_id, anonymous, created_at, updated_at, last_activity_at}).
 -record(contact_address, {id, address, contact_id, project_id, created_at, updated_at}).
 -record(delayed_job, {id, handler, run_at, created_at, updated_at}).
 -record(external_service, {id, project_id, guid, global_settings, created_at, updated_at}).

--- a/broker/src/call_log_srv.erl
+++ b/broker/src/call_log_srv.erl
@@ -64,9 +64,12 @@ handle_cast({log, Level, Message, Details}, State = #state{call_log = CallLog, t
 
 handle_cast({update, Fields}, State = #state{call_log = CallLog, timeout = Timeout}) ->
   NewCallLog = CallLog:update(Fields),
-  case proplists:get_value(finished_at, Fields) of
-    undefined -> ok;
-    FinishedAt -> contact:update_last_activity(CallLog#call_log.contact_id, FinishedAt)
+  case is_list(Fields) of
+    true -> case proplists:get_value(finished_at, Fields) of
+              undefined -> ok;
+              FinishedAt -> contact:update_last_activity(CallLog#call_log.contact_id, FinishedAt)
+            end;
+    _ -> ok
   end,
   {noreply, State#state{call_log = NewCallLog}, Timeout};
 

--- a/broker/src/call_log_srv.erl
+++ b/broker/src/call_log_srv.erl
@@ -64,6 +64,10 @@ handle_cast({log, Level, Message, Details}, State = #state{call_log = CallLog, t
 
 handle_cast({update, Fields}, State = #state{call_log = CallLog, timeout = Timeout}) ->
   NewCallLog = CallLog:update(Fields),
+  case proplists:get_value(finished_at, Fields) of
+    undefined -> ok;
+    FinishedAt -> contact:update_last_activity(CallLog#call_log.contact_id, FinishedAt)
+  end,
   {noreply, State#state{call_log = NewCallLog}, Timeout};
 
 handle_cast({trace_record, CallFlowId, StepId, StepName, Result}, State = #state{call_log = CallLog, timeout = Timeout}) ->

--- a/broker/src/models/contact.erl
+++ b/broker/src/models/contact.erl
@@ -1,5 +1,5 @@
 -module(contact).
--export ([find_or_create_with_address/2, create_anonymous/2]).
+-export ([find_or_create_with_address/2, create_anonymous/2, update_last_activity/2]).
 -define(TABLE_NAME, "contacts").
 -include_lib("erl_dbmodel/include/model.hrl").
 
@@ -17,3 +17,9 @@ create_anonymous(ProjectId, Address) ->
   Contact = contact:create(#contact{project_id = ProjectId, anonymous = 1}),
   contact_address:create(#contact_address{project_id = ProjectId, contact_id = Contact#contact.id, address = Address}),
   Contact.
+
+update_last_activity(undefined, LastActivity) ->
+  LastActivity;
+update_last_activity(ContactId, LastActivity) ->
+  db:update(io_lib:format("UPDATE contacts SET last_activity_at = GREATEST(last_activity_at, CAST('~s' AS datetime)) WHERE id = ~b", [mysql:encode(LastActivity), ContactId])),
+  LastActivity.

--- a/db/migrate/20161012205827_add_last_activity_at_to_contacts.rb
+++ b/db/migrate/20161012205827_add_last_activity_at_to_contacts.rb
@@ -1,0 +1,20 @@
+class AddLastActivityAtToContacts < ActiveRecord::Migration
+  def up
+    add_column :contacts, :last_activity_at, :datetime
+
+    ActiveRecord::Base.connection.execute <<-SQL
+      UPDATE contacts SET last_activity_at = (
+        SELECT call_logs.finished_at
+        FROM call_logs
+        WHERE call_logs.finished_at IS NOT NULL
+          AND call_logs.contact_id = contacts.id
+        ORDER BY call_logs.finished_at DESC
+        LIMIT 1
+      )
+    SQL
+  end
+
+  def down
+    remove_column :contacts, :last_activity_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160926180733) do
+ActiveRecord::Schema.define(:version => 20161012205827) do
 
   create_table "accounts", :force => true do |t|
     t.string   "email",                               :default => "", :null => false
@@ -153,10 +153,11 @@ ActiveRecord::Schema.define(:version => 20160926180733) do
   add_index "contact_scheduled_calls", ["scheduled_call_id"], :name => "index_contact_scheduled_calls_on_scheduled_call_id"
 
   create_table "contacts", :force => true do |t|
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
     t.boolean  "anonymous"
     t.integer  "project_id"
+    t.datetime "last_activity_at"
   end
 
   add_index "contacts", ["project_id"], :name => "index_contacts_on_project_id"
@@ -379,12 +380,12 @@ ActiveRecord::Schema.define(:version => 20160926180733) do
 
   create_table "projects", :force => true do |t|
     t.string   "name"
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.datetime "created_at",                                      :null => false
+    t.datetime "updated_at",                                      :null => false
     t.integer  "account_id"
     t.string   "status_callback_url"
     t.text     "encrypted_config"
-    t.string   "time_zone",           :default => "UTC"
+    t.string   "time_zone",                    :default => "UTC"
     t.text     "languages"
     t.string   "default_language"
     t.boolean  "status_callback_include_vars", :default => false

--- a/spec/models/contacts_finder_spec.rb
+++ b/spec/models/contacts_finder_spec.rb
@@ -299,7 +299,6 @@ describe ContactsFinder do
       ContactAddress.delete_all
 
       contact_a.addresses.create(project_id: project.id, address: '30')
-      contact_a.addresses.create(project_id: project.id, address: '15')
 
       contact_b.addresses.create(project_id: project.id, address: '10')
       contact_b.addresses.create(project_id: project.id, address: '40')
@@ -322,6 +321,16 @@ describe ContactsFinder do
 
       contacts = finder.find([], {sorting: {implicit_key: 'language', direction: 'ASC'}})
       contacts.map(&:id).should eq([contact_d, contact_b, contact_c, contact_a].map(&:id))
+    end
+
+    it "should sort contacts by last activity" do
+      contact_a.update_column :last_activity_at, 5.days.ago
+      contact_b.update_column :last_activity_at, 8.days.ago
+      contact_c.update_column :last_activity_at, nil
+      contact_d.update_column :last_activity_at, 1.day.ago
+
+      contacts = finder.find([], {sorting: {last_activity: true, direction: 'ASC'}})
+      contacts.map(&:id).should eq([contact_c, contact_b, contact_a, contact_d].map(&:id))
     end
 
   end


### PR DESCRIPTION
Store last activity as a new column in contacts, updating it whenever a call log is updated as finished. Depends on PR #751.

Fixes #741.