### PR TITLE
Phonebook filters by implicit variables and addresses

### DIFF
--- a/app/assets/javascripts/contacts_filter.js.coffee
+++ b/app/assets/javascripts/contacts_filter.js.coffee
@@ -27,11 +27,11 @@ class Filter
     @other_types = ['value', 'variable']
     @other_type = ko.observable()
 
-    if attrs.project_variable_id?
-      @variable(_.find(window.variables, (v) -> v.id == attrs.project_variable_id))
+    if variable_id = attrs.project_variable_id or attrs.implicit_key
+      @variable(_.find(window.variables, (v) -> v.id == variable_id))
 
-    if attrs.other_project_variable_id?
-      @other_variable(_.find(window.variables, (v) -> v.id == attrs.other_project_variable_id))
+    if other_variable_id = attrs.other_project_variable_id or attrs.other_implicit_key
+      @other_variable(_.find(window.variables, (v) -> v.id == other_variable_id))
       @other_type('variable')
     else
       @value(attrs.value || '')
@@ -62,17 +62,26 @@ class Filter
         "#{@variable()?.name} #{@operator()?.text} #{right}"
 
   to_hash: =>
-    {
-      project_variable_id: @variable()?.id
-      operator: @operator()?.value
-      value: @value() if @other_type() == 'value'
-      other_project_variable_id: @other_variable()?.id if @other_type() == 'variable'
-    }
+    hash = { operator: @operator()?.value }
+
+    if @variable()?.implicit
+      hash.implicit_key = @variable().id
+    else if @variable()?.id?
+      hash.project_variable_id = @variable().id
+
+    unless @operator()?.unary
+      if @other_type() == 'value'
+        hash.value = @value()
+      else if @other_type() == 'variable'
+        if @other_variable()?.implicit
+          hash.other_implicit_key = @other_variable().id
+        else if @other_variable()?.id?
+          hash.other_project_variable_id = @other_variable().id
+
+    return hash
 
   expand: =>
     @expanded(true)
 
   close: =>
     @expanded(false)
-
-

--- a/app/assets/javascripts/contacts_filter.js.coffee
+++ b/app/assets/javascripts/contacts_filter.js.coffee
@@ -6,6 +6,7 @@ class @ContactsFilter
       if @count()? then "(#{if @count() == 0 then 'no' else @count()} #{if @count() == 1 then 'contact' else 'contacts'} found)" else ""
     @json = ko.computed =>
       ko.toJSON(filter.to_hash() for filter in @filters())
+    @variablesAndFields = window.fields.concat(window.variables);
 
   addFilter: =>
     filter = new Filter()
@@ -29,6 +30,8 @@ class Filter
 
     if variable_id = attrs.project_variable_id or attrs.implicit_key
       @variable(_.find(window.variables, (v) -> v.id == variable_id))
+    else if attrs.field_name
+      @variable(_.find(window.fields, (v) -> v.id == attrs.field_name))
 
     if other_variable_id = attrs.other_project_variable_id or attrs.other_implicit_key
       @other_variable(_.find(window.variables, (v) -> v.id == other_variable_id))
@@ -66,6 +69,8 @@ class Filter
 
     if @variable()?.implicit
       hash.implicit_key = @variable().id
+    else if @variable()?.field
+      hash.field_name = @variable().id
     else if @variable()?.id?
       hash.project_variable_id = @variable().id
 

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -28,6 +28,7 @@ class ContactsController < ApplicationController
     @page = params[:page] || 1
     @contacts = ContactsFinder.for(@project).find(@filters, includes: [:addresses, :recorded_audios, :persisted_variables, :project_variables], sorting: @sorting)
     @project_variables = @project.project_variables
+    @fields = ContactsFinder.contact_fields
     @implicit_variables = ImplicitVariable.subclasses
 
     respond_to do |format|

--- a/app/controllers/scheduled_calls_controller.rb
+++ b/app/controllers/scheduled_calls_controller.rb
@@ -41,5 +41,6 @@ private
 
   def setup_variables
     @variables = project.project_variables.map{|x| {id: x.id, name: x.name} }
+    @implicit_variables = ImplicitVariable.subclasses
   end
 end

--- a/app/controllers/scheduled_calls_controller.rb
+++ b/app/controllers/scheduled_calls_controller.rb
@@ -42,5 +42,6 @@ private
   def setup_variables
     @variables = project.project_variables.map{|x| {id: x.id, name: x.name} }
     @implicit_variables = ImplicitVariable.subclasses
+    @fields = ContactsFinder.contact_fields
   end
 end

--- a/app/models/implicit_variable.rb
+++ b/app/models/implicit_variable.rb
@@ -29,8 +29,20 @@ class ImplicitVariable
     subclass_responsibility
   end
 
+  def self.label
+    self.key.humanize
+  end
+
   def self.find(key)
     self.subclasses.detect{|s| s.key == key}
+  end
+
+  def self.implicit
+    true
+  end
+
+  def self.as_json(opts={})
+    { key: key, id: key, name: label, implicit: implicit }
   end
 
 end

--- a/app/models/implicit_variables/sms_number.rb
+++ b/app/models/implicit_variables/sms_number.rb
@@ -33,5 +33,9 @@ module ImplicitVariables
       'sms_number'
     end
 
+    def self.label
+      "SMS number"
+    end
+
   end
 end

--- a/app/views/contacts/index.html.haml
+++ b/app/views/contacts/index.html.haml
@@ -72,4 +72,5 @@
 
 :javascript
   window.variables = #{(@project_variables + @implicit_variables).to_json};
+  window.fields = #{@fields.to_json};
   initContactsFilter(#{@contacts.total_count})

--- a/app/views/contacts/index.html.haml
+++ b/app/views/contacts/index.html.haml
@@ -71,5 +71,5 @@
 %br.clear
 
 :javascript
-  window.variables = #{@project_variables.to_json};
+  window.variables = #{(@project_variables + @implicit_variables).to_json};
   initContactsFilter(#{@contacts.total_count})

--- a/app/views/scheduled_calls/index.html.haml
+++ b/app/views/scheduled_calls/index.html.haml
@@ -1,5 +1,5 @@
 :javascript
-  window.variables = #{@variables.to_json};
+  window.variables = #{(@variables + @implicit_variables).to_json};
   initScheduledCalls();
 
 = render 'shared/project_tabs_and_title', :project => project, :shared_project => @shared_project

--- a/app/views/scheduled_calls/index.html.haml
+++ b/app/views/scheduled_calls/index.html.haml
@@ -1,5 +1,6 @@
 :javascript
   window.variables = #{(@variables + @implicit_variables).to_json};
+  window.fields = #{@fields.to_json};
   initScheduledCalls();
 
 = render 'shared/project_tabs_and_title', :project => project, :shared_project => @shared_project

--- a/app/views/shared/_contacts_filter.html.haml
+++ b/app/views/shared/_contacts_filter.html.haml
@@ -1,7 +1,7 @@
 %ul{'data-bind' => 'foreach: filters'}
   %li
     /ko if: expanded()
-    %select{'data-bind' => "options: window.variables, optionsText: 'name', value: variable"}
+    %select{'data-bind' => "options: $parent.variablesAndFields, optionsText: 'name', value: variable"}
     %select{'data-bind' => "options: operators, optionsText: 'text', value: operator"}
     / ko ifnot: unary()
     %select{'data-bind' => "options: other_types, value: other_type"}

--- a/spec/controllers/api/schedules_controller_spec.rb
+++ b/spec/controllers/api/schedules_controller_spec.rb
@@ -44,11 +44,14 @@ describe Api::SchedulesController do
   end
 
   it "create custom schedule" do
-    data = {project_id: project.id, name: "foo", :time_from_str => Time.now.to_s, :time_to_str => (Time.now + 1.hour).to_s}
+    data = {project_id: project.id, name: "foo", :time_from_str => Time.gm(2000, 1, 1, 10, 0), :time_to_str => Time.gm(2000, 1, 1, 11, 0)}
     @request.env['RAW_POST_DATA'] = data.to_json
     post :create, project_id: project.id, format: :json
 
     assert_response :ok
+    response = JSON.parse(@response.body).with_indifferent_access
+    response[:name].should eq("foo"), "Expected response to contain schedule name 'foo', but was: #{@response.body}"
+
     schedules = project.schedules.all
     schedules.size.should == 1
     schedules[0].name.should == data[:name]

--- a/spec/models/contacts_finder_spec.rb
+++ b/spec/models/contacts_finder_spec.rb
@@ -254,6 +254,69 @@ describe ContactsFinder do
       contacts.should include(contact_b)
     end
 
+    context "by address" do
+
+      let!(:contact_c) { Contact.make project: project }
+      let!(:contact_d) { Contact.make project: project }
+
+      before(:each) do
+        ContactAddress.delete_all
+
+        contact_a.addresses.create!(project_id: project.id, address: '30')
+        contact_a.addresses.create!(project_id: project.id, address: '10')
+
+        contact_b.addresses.create!(project_id: project.id, address: '15')
+        contact_b.addresses.create!(project_id: project.id, address: '40')
+
+        contact_c.addresses.create!(project_id: project.id, address: '20')
+        contact_c.addresses.create!(project_id: project.id, address: '60')
+      end
+
+      it "should find contacts by address equal to a value" do
+        contacts = finder.find([
+          {field_name: "address", operator: :eq, value: '15'}
+        ])
+
+        contacts.should include(contact_b)
+      end
+
+      it "should find contacts by address defined" do
+        contacts = finder.find([
+          {field_name: "address", operator: :defined}
+        ])
+
+        contacts.should include(contact_a, contact_b, contact_c)
+      end
+
+      it "should find contacts by address undefined" do
+        contacts = finder.find([
+          {field_name: "address", operator: :undefined}
+        ])
+
+        contacts.should include(contact_d)
+      end
+
+      it "should find contacts by address greater than a value" do
+        contacts = finder.find([
+          {field_name: "address", operator: :geq, value: '35'}
+        ])
+
+        contacts.should include(contact_b, contact_c)
+      end
+
+      it "should find contacts by address equal to a variable" do
+        PersistedVariable.make contact: contact_a, project_variable: age, value: '30'
+        PersistedVariable.make contact: contact_b, project_variable: age, value: '35'
+
+        contacts = finder.find([
+          {field_name: "address", operator: :eq, other_project_variable_id: age.id}
+        ])
+
+        contacts.should include(contact_a)
+      end
+
+    end
+
   end
 
   context "sorting" do

--- a/spec/models/contacts_finder_spec.rb
+++ b/spec/models/contacts_finder_spec.rb
@@ -237,6 +237,23 @@ describe ContactsFinder do
       contacts.should include(contact_a)
     end
 
+    it "should find with variable equal to variable" do
+      other = ProjectVariable.make name: 'other', project: project
+
+      PersistedVariable.make contact: contact_a, project_variable: age, value: '17'
+      PersistedVariable.make contact: contact_a, project_variable: other, value: '20'
+
+      PersistedVariable.make contact: contact_b, project_variable: age, value: '23'
+      PersistedVariable.make contact: contact_b, project_variable: other, value: '23'
+
+      contacts = finder.find([
+        {project_variable_id: age.id, operator: :eq, other_project_variable_id: other.id}
+      ])
+
+      contacts.size.should eq(1)
+      contacts.should include(contact_b)
+    end
+
   end
 
   context "sorting" do


### PR DESCRIPTION
Allows filtering a project's phonebook by implicit variables (language and sms number) and addresses (phone numbers). Phone numbers can only be used in left-hand-side comparisons, and if any phone number of a contact matches, then the contact is returned.

Fixes #713.

Depends on PR #752.