### PR TITLE
Save Twilio errors information

### DIFF
--- a/app/helpers/call_log_helper.rb
+++ b/app/helpers/call_log_helper.rb
@@ -20,8 +20,9 @@ module CallLogHelper
     return nil if call_log.fail_reason.nil?
     info = content_tag(:span, "#{call_log.fail_reason.capitalize}. ")
     if call_log.fail_code
-      fail_details = call_log.fail_details ? "#{call_log.fail_details} (#{call_log.fail_code})" : "Code #{call_log.fail_code}."
-      info << link_to_if(link, fail_details, error_code_url(call_log.fail_code), class: 'call-log-fail-info')
+      fail_details = call_log.fail_details ? "#{call_log.fail_details} (#{call_log.fail_code.slice(/\w+:(.+)/, 1)})" : "Code #{call_log.fail_code}."
+      url = error_code_url(call_log.fail_code)
+      info << link_to_if(link && url, fail_details, url, class: 'call-log-fail-info')
     elsif call_log.fail_details
       info << content_tag(:span, "#{call_log.fail_details}.")
     end
@@ -29,9 +30,10 @@ module CallLogHelper
   end
 
   def error_code_url(code)
-    url = "https://github.com/instedd/verboice/wiki/Error-codes"
-    url << "##{code.gsub(':', '').downcase}" if code
-    url
+    if code.downcase.starts_with?("twilio:")
+      "https://www.twilio.com/docs/errors/#{code.slice(/twilio:(.+)/, 1)}"
+    elsif code.downcase.starts_with?("isdn:")
+      "https://github.com/instedd/verboice/wiki/Error-codes##{code.gsub(':', '').downcase}"
+    end
   end
 end
-

--- a/broker/src/asterisk/asterisk_pbx_log_srv.erl
+++ b/broker/src/asterisk/asterisk_pbx_log_srv.erl
@@ -54,7 +54,11 @@ handle_cast({varset, Event}, State=#state{guid=Guid}) ->
 
 handle_cast({hangup, Event}, State=#state{guid=Guid,session_id=SessionId}) ->
   Reason = proplists:get_value('cause-txt', Event),
-  Code = proplists:get_value(cause, Event),
+  Code = case proplists:get_value(cause, Event) of
+    undefined -> undefined;
+    <<"0">> -> undefined;
+    C -> "ISDN:" ++ binary_to_list(C)
+  end,
   create_log(Guid, ["Channel hangup. Reason: ", Reason]),
   call_log_srv:hangup(SessionId, {Code, Reason}),
   {stop, normal, State};

--- a/broker/src/call_log_srv.erl
+++ b/broker/src/call_log_srv.erl
@@ -93,12 +93,7 @@ handle_cast({hangup, {_Code, <<"Unknown">>}}, State = #state{timeout = Timeout})
   {noreply, State, Timeout};
 
 handle_cast({hangup, {Code, Reason}}, State = #state{call_log = CallLog, timeout = Timeout}) ->
-  FullCode = case Code of
-    undefined -> undefined;
-    <<"0">> -> undefined;
-    _ -> "ISDN:" ++ binary_to_list(Code)
-  end,
-  NewCallLog = call_log:update(CallLog#call_log{fail_code = FullCode, fail_details = Reason}),
+  NewCallLog = call_log:update(CallLog#call_log{fail_code = Code, fail_details = Reason}),
   {noreply, State#state{call_log = NewCallLog}, Timeout}.
 
 %% @private

--- a/broker/src/twilio/twilio_broker.erl
+++ b/broker/src/twilio/twilio_broker.erl
@@ -1,9 +1,13 @@
 -module(twilio_broker).
--export([start_link/0, init/0, dispatch/1, create_channel/1, destroy_channel/1, get_channel_status/1]).
+-export([start_link/0, init/0, dispatch/1, create_channel/1, destroy_channel/1, get_channel_status/1, parse_exception/2]).
 
 -behaviour(broker).
 -include("session.hrl").
 -include("uri.hrl").
+
+-include_lib("xmerl/include/xmerl.hrl").
+
+-compile([{parse_transform, lager_transform}]).
 
 start_link() ->
   broker:start_link(?MODULE).
@@ -32,11 +36,36 @@ dispatch(_Session = #session{session_id = SessionId, channel = Channel, address 
   ],
 
   Response = uri:post_form(RequestBody, [{basic_auth, {AccountSid, AuthToken}}], RequestUrl),
-  io:format("Response: ~p~n", [Response]),
+  lager:info("Twilio response: ~p~n", [Response]),
   case Response of
     {ok, {{_, 201, _}, _, _}} -> ok;
-    {ok, {{_, _, Reason}, _, _}} -> {error, Reason};
+    {ok, {{_, _, Reason}, _, Msg}} -> {error, parse_exception(Reason, Msg)};
     _ ->
       timer:apply_after(timer:minutes(1), broker, notify_ready, [?MODULE]),
       {error, unavailable}
   end.
+
+parse_exception(Reason, Message) ->
+  try
+    {#xmlElement{content = [RestException]}, _} = xmerl_scan:string(Message),
+    case RestException#xmlElement.name of
+      'RestException' ->
+        Content = RestException#xmlElement.content,
+        FullCode = case extract_exception_item('Code', Content) of
+          undefined -> undefined;
+          Code -> "twilio:" ++ Code
+        end,
+        {error, extract_exception_item('Message', Content), FullCode};
+      _ -> Reason
+    end
+  catch
+    _ -> Reason
+  end.
+
+extract_exception_item(TargetName, [#xmlElement{name = Name, content = [#xmlText{value = Text}]} | Rest]) ->
+  case Name of
+    TargetName -> Text;
+    _ -> extract_exception_item(TargetName, Rest)
+  end;
+extract_exception_item(_, []) ->
+  undefined.

--- a/broker/test/twilio_broker_test.erl
+++ b/broker/test/twilio_broker_test.erl
@@ -1,0 +1,6 @@
+-module(twilio_broker_test).
+-include_lib("eunit/include/eunit.hrl").
+
+parse_exception_test() ->
+  XmlString = "<?xml version='1.0' encoding='UTF-8'?>\n<TwilioResponse><RestException><Code>13223</Code><Message>The phone number you are attempting to call, 12345, is not valid.</Message><MoreInfo>https://www.twilio.com/docs/errors/13223</MoreInfo><Status>400</Status></RestException></TwilioResponse>",
+  ?assertEqual({error, "The phone number you are attempting to call, 12345, is not valid.", "twilio:13223"}, twilio_broker:parse_exception("", XmlString)).


### PR DESCRIPTION
Any errors when issuing a Twilio outgoing call (such as an invalid number) are now captured and displayed in the call log details, along with a link to the Twilio documentation for more information.

Fixes #742