### PR TITLE
Support additional variables in call flow steps

### DIFF
--- a/app/assets/javascripts/workflow/steps/external_step_setting.js.coffee
+++ b/app/assets/javascripts/workflow/steps/external_step_setting.js.coffee
@@ -15,25 +15,6 @@ onWorkflow ->
         display_name: @display_name
       }
 
-    content_kinds: () =>
-      return [{text: 'Variable', value: 'variable'},
-      {text: 'Step', value: 'step'},
-      {text: 'Response', value: 'response'},
-      {text: 'Value', value: 'value'}]
-
-    available_variables: () =>
-      workflow.all_variables().sort()
-
-    available_steps: () =>
-      {name: step.name(), value: step.id} for step in workflow.steps() when (step.type() == 'capture') || (step.type() == 'menu')
-
-    available_responses: () =>
-      _.flatten({name: "#{step.name()} - #{variable.display_name}", value: "#{step.id}_#{variable.name}"} for variable in step.response_variables() for step in workflow.steps() when step.response_variables?)
-
-    on_step_removed: (step) =>
-      @step_id(null) if step.id == parseInt(@step_id())
-      @response(null) if step.id == parseInt(@response()) # Note that parseInt("123_resp") == "123"
-
     description: () =>
       desc = super()
       if desc? then "(#{desc})" else null

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -63,7 +63,7 @@ class Project < ActiveRecord::Base
   after_save :telemetry_track_activity
 
   def defined_variables
-    project_variables.collect(&:name)
+    project_variables.collect(&:name) + [ImplicitVariables::Language.key, ImplicitVariables::SmsNumber.key]
   end
 
   def update_variables_with variable_names

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -109,7 +109,7 @@ describe Project do
       'max_input_length' => 2,
       'timeout' => 10 }]
 
-      project.reload.defined_variables.should eq(['some_variable', 'foo'])
+      project.reload.defined_variables.should eq(['some_variable', 'foo', 'language', 'sms_number'])
     end
   end
 


### PR DESCRIPTION
- External service steps and Write variable steps can now set sms_number and language as the response
- External services can use phone_number, sms_number and language as settings
- Branch steps can use phone_number, sms_number and language in branch conditions

Fixes #578 
Fixes #760
