### PR TITLE
Customize upstart templates to generate pidfiles

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -169,7 +169,7 @@ Listen 8080"' >> /etc/apache2/ports.conf
     script/update_yml_config config/verboice.yml skip_account_confirmation true
     echo "RAILS_ENV=production" > .env
     echo "HOME=$HOME" >> .env
-    sudo -E bundle exec foreman export upstart /etc/init -a verboice -u `whoami` --concurrency="broker=1,delayed=1"
+    sudo -E bundle exec foreman export upstart /etc/init -a verboice -u `whoami` -t etc/upstart --concurrency="broker=1,delayed=1"
 
     # Setup admin interface
     cd ~/verboice/admin

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -77,10 +77,10 @@ namespace :foreman do
   task :export, :roles => :app do
     if ENV['RVM']
       run "echo -e \"HOME=$HOME\\nPATH=$PATH\\nGEM_HOME=$GEM_HOME\\nGEM_PATH=$GEM_PATH\\nRAILS_ENV=production\" >  #{current_path}/.env"
-      run "cd #{current_path} && rvmsudo bundle exec foreman export upstart /etc/init -f #{current_path}/Procfile -a #{application} -u #{user} --concurrency=\"broker=1,delayed=1\""
+      run "cd #{current_path} && rvmsudo bundle exec foreman export upstart /etc/init -f #{current_path}/Procfile -a #{application} -u #{user} -t #{current_path}/etc/upstart --concurrency=\"broker=1,delayed=1\""
     else
       run "echo -e \"HOME=$HOME\\nPATH=$PATH\\nRAILS_ENV=production\" >  #{current_path}/.env"
-      run "cd #{current_path} && #{try_sudo} `which bundle` exec foreman export upstart /etc/init -f #{current_path}/Procfile -a #{application} -u #{user} --concurrency=\"broker=1,delayed=1\""
+      run "cd #{current_path} && #{try_sudo} `which bundle` exec foreman export upstart /etc/init -f #{current_path}/Procfile -a #{application} -u #{user} -t #{current_path}/etc/upstart --concurrency=\"broker=1,delayed=1\""
     end
   end
 

--- a/etc/upstart/master.conf.erb
+++ b/etc/upstart/master.conf.erb
@@ -1,0 +1,16 @@
+pre-start script
+
+bash << "EOF"
+<% run_dir = "/var/run/#{app}"  %>
+mkdir -p <%= run_dir %>
+chown -R <%= user %> <%= run_dir %>
+
+mkdir -p <%= log %>
+chown -R <%= user %> <%= log %>
+EOF
+
+end script
+
+start on runlevel [2345]
+
+stop on runlevel [016]

--- a/etc/upstart/process.conf.erb
+++ b/etc/upstart/process.conf.erb
@@ -1,0 +1,8 @@
+start on starting <%= app %>-<%= name %>
+stop on stopping <%= app %>-<%= name %>
+respawn
+
+script
+  echo $$ > /var/run/<%= app %>/<%= name %>.pid
+  exec su - <%= user %> -c 'cd <%= engine.root %>; export PORT=<%= port %>;<% engine.env.each_pair do |var,env| %> export <%= var.upcase %>=<%= shell_quote(env) %>; <% end %> <%= process.command %> >> <%= log %>/<%=name%>-<%=num%>.log 2>&1'
+end script

--- a/etc/upstart/process_master.conf.erb
+++ b/etc/upstart/process_master.conf.erb
@@ -1,0 +1,2 @@
+start on starting <%= app %>
+stop on stopping <%= app %>


### PR DESCRIPTION
Now both the broker and delayed job services generate pid files in
/var/verboice to allow monitoring their processes.