### PR TITLE
Support NAT SIP clients in PJSIP configuration

### DIFF
--- a/broker/src/asterisk/asterisk_config.erl
+++ b/broker/src/asterisk/asterisk_config.erl
@@ -50,6 +50,10 @@ generate_config([Channel | Rest], ConfigFile, ResolvCache, ChannelIndex, Registr
       file:write(ConfigFile, "disallow=all\n"),
       file:write(ConfigFile, "allow=ulaw\n"),
       file:write(ConfigFile, "allow=gsm\n"),
+      file:write(ConfigFile, "rtp_symmetric=yes\n"),
+      file:write(ConfigFile, "direct_media=no\n"),
+      file:write(ConfigFile, "rewrite_contact=yes\n"),
+      file:write(ConfigFile, "identify_by=auth_username\n"),
       file:write(ConfigFile, "\n"),
 
       % Auth
@@ -58,6 +62,7 @@ generate_config([Channel | Rest], ConfigFile, ResolvCache, ChannelIndex, Registr
       file:write(ConfigFile, "auth_type=userpass\n"),
       file:write(ConfigFile, ["username=", Section, "\n"]),
       file:write(ConfigFile, ["password=", Password, "\n"]),
+      file:write(ConfigFile, "remove_existing=yes\n"),
       file:write(ConfigFile, "\n"),
 
       % AOR


### PR DESCRIPTION
* `rtp_symmetric` and `direct_media` are required for audio
to flow between the client and server

* `rewrite_contact` is needed for asterisk to ignore the contact
line from the client and use the IP and port that sent the request

* `identify_by` is needed for asterisk to use the auth username
instead of the FROM field (which contains the caller id) to id
the endpoint which owns the call