### PR TITLE
Implement channel disabling

### DIFF
--- a/app/assets/stylesheets/channels.scss
+++ b/app/assets/stylesheets/channels.scss
@@ -1,0 +1,22 @@
+td.channel-disabled, span.channel-disabled {
+  font-style: italic;
+  color: #888;
+
+  span.channel-status {
+    background-color: transparent;
+  }
+}
+
+span.channel-status {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background-color: #d0d0d0;
+
+  &.channel-status-ok {
+    background-color: #6bd346;
+  }
+  &.channel-status-error {
+    background-color: #ff642a;
+  }
+}

--- a/app/controllers/api/channels_controller.rb
+++ b/app/controllers/api/channels_controller.rb
@@ -79,6 +79,26 @@ module Api
       end
     end
 
+    def enable
+      channel = current_account.channels.find_by_id(params[:id])
+      if channel.present?
+        channel.enable!
+        head :ok
+      else
+        head :not_found
+      end
+    end
+
+    def disable
+      channel = current_account.channels.find_by_id(params[:id])
+      if channel.present?
+        channel.disable!
+        head :ok
+      else
+        head :not_found
+      end
+    end
+
     def list
       channel_names = current_account.channels.map(&:name)
       render :json => channel_names

--- a/app/controllers/call_logs_controller.rb
+++ b/app/controllers/call_logs_controller.rb
@@ -17,7 +17,7 @@
 
 class CallLogsController < ApplicationController
   before_filter :authenticate_account!
-  before_filter :prepare_log_detail, only: [:show, :download_details]
+  before_filter :prepare_log_detail, only: [:show, :progress, :download_details]
 
   def index
   end
@@ -27,7 +27,12 @@ class CallLogsController < ApplicationController
   end
 
   def progress
-    @log = current_account.call_logs.find params[:id]
+    @log.entries.each do |entry|
+      if entry.details.has_key?(:activity)
+        activity = JSON.load(entry.details[:activity]) rescue {}
+        entry.details[:description] = activity["body"]["@description"] rescue nil
+      end
+    end
     render :layout => false
   end
 

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -115,7 +115,7 @@ class ChannelsController < ApplicationController
   end
 
   def call
-    render :layout => false
+    redirect_to(@channel, :notice => "Channel is disabled") unless @channel.enabled?
   end
 
   private

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -19,7 +19,7 @@ class ChannelsController < ApplicationController
   before_filter :authenticate_account!
   before_filter :load_call_flows, only: [:new, :edit, :create]
   before_filter :load_channel, only: [:show, :edit, :update, :destroy, :call]
-  before_filter :check_channel_admin, only: [:update, :destroy]
+  before_filter :check_channel_admin, only: [:update, :destroy, :enable, :disable]
 
   # GET /channels
   def index
@@ -98,6 +98,20 @@ class ChannelsController < ApplicationController
     @channel.destroy
 
     redirect_to(channels_url)
+  end
+
+  # POST /channels/1/enable
+  def enable
+    @channel.enable!
+
+    redirect_to(@channel)
+  end
+
+  # POST /channels/1/disable
+  def disable
+    @channel.disable!
+
+    redirect_to(@channel)
   end
 
   def call

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,6 +62,7 @@ class ProjectsController < ApplicationController
 
     @channel = @channels.find { |c| c.id == params[:channel_id].to_i }
     redirect_to project_path(params[:id]), flash: {error: 'You need to select a channel'} and return unless @channel
+    redirect_to project_path(params[:id]), flash: {error: 'The channel is disabled'} and return unless @channel.enabled?
 
     addresses = params[:addresses].split(/\n/).map(&:strip).select(&:presence)
 
@@ -103,7 +104,7 @@ class ProjectsController < ApplicationController
 
   def load_enqueue_call_fields
     load_project
-    @channels = current_account.channels.all
+    @channels = current_account.enabled_channels.all
 
     shared_channels = current_account.shared_channels.all.map(&:channel)
     shared_channels.each { |c| c.name = "#{c.name} (shared)" }

--- a/app/helpers/channel_helper.rb
+++ b/app/helpers/channel_helper.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2010-2012, InSTEDD
+#
+# This file is part of Verboice.
+#
+# Verboice is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Verboice is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Verboice.  If not, see <http://www.gnu.org/licenses/>.
+
+module ChannelHelper
+  def channel_row_class(channel)
+    channel.enabled? ? "" : "channel-disabled"
+  end
+
+  def channel_status_class(status)
+    if status.nil?
+      ""
+    elsif status[:ok]
+      "channel-status-ok"
+    else
+      "channel-status-error"
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,7 @@ class Account < ActiveRecord::Base
   has_many :identities, dependent: :destroy
 
   has_one :google_oauth_token, :class_name => 'OAuthToken', :conditions => {:service => :google}, :dependent => :destroy
+  has_many :enabled_channels, :class_name => 'Channel', :conditions => {:enabled => true}
 
   after_save :telemetry_track_activity
 

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -26,6 +26,8 @@ class Channel < ActiveRecord::Base
 
   config_accessor :limit
 
+  scope :enabled_channels, ->() { where(enabled: true) }
+
   validates_presence_of :account
 
   validates_presence_of :name
@@ -56,6 +58,16 @@ class Channel < ActiveRecord::Base
 
   def self.enabled
     true
+  end
+
+  def enable!
+    self.enabled = true
+    save!
+  end
+
+  def disable!
+    self.enabled = false
+    save!
   end
 
   def call(address, options = {})

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -266,7 +266,8 @@ class Channel < ActiveRecord::Base
     super(options).merge({
       kind: kind.try(:downcase).try(:gsub, ' ', '_'),
       call_flow: call_flow.try(:name),
-      call_flow_id: call_flow.try(:id)
+      call_flow_id: call_flow.try(:id),
+      enabled: enabled
     })
   end
 end

--- a/app/models/scheduled_call.rb
+++ b/app/models/scheduled_call.rb
@@ -34,6 +34,7 @@ class ScheduledCall < ActiveRecord::Base
 
   def make_calls(from, to)
     return unless self.enabled
+    return unless self.channel.enabled?
 
     call_options = {
       account: self.project.account,

--- a/app/views/channels/index.haml
+++ b/app/views/channels/index.haml
@@ -18,13 +18,15 @@
     - else
       - @all_channels.each do |channel, permission|
         %tr.link{'data-url' => channel_path(channel)}
-          %td
+          %td{'class' => channel_row_class(channel)}
             - status = @channel_status[channel.id]
             - status_ok = status.nil? || status[:ok]
-            %span{style: "display: inline-block; width: 10px; height: 10px; background-color: #{ status ? (status_ok ? '#6BD346' : '#FF642A') : '#D0D0D0' }"}
+            %span.channel-status{'class' => channel_status_class(status)}
             = channel.name
             - if permission
               (shared as #{permission})
+            - unless channel.enabled?
+              &mdash; disabled
             - unless status_ok
               %br
               - status[:messages].each do |message|

--- a/app/views/channels/show.haml
+++ b/app/views/channels/show.haml
@@ -50,7 +50,7 @@
 
 - if channel_admin?
   - if @channel.enabled?
-    = link_to 'Disable this channel', disable_channel_path(@channel), :confirm => "Disable the channel #{@channel.name}?", :method => :post, :class => "button fstop"
+    = link_to 'Disable this channel', disable_channel_path(@channel), :confirm => "Disable the channel #{@channel.name}? All pending queued calls will be cancelled.", :method => :post, :class => "button fstop"
   - else
     = link_to 'Enable this channel', enable_channel_path(@channel), :confirm => "Enable the channel #{@channel.name}?", :method => :post, :class => "button fplay"
   = link_to 'Delete this channel', @channel, :confirm => "Are you sure you want to delete the channel #{@channel.name}?", :method => :delete, :class => "button fdelete"

--- a/app/views/channels/show.haml
+++ b/app/views/channels/show.haml
@@ -49,5 +49,9 @@
 %hr
 
 - if channel_admin?
+  - if @channel.enabled?
+    = link_to 'Disable this channel', disable_channel_path(@channel), :confirm => "Disable the channel #{@channel.name}?", :method => :post, :class => "button fstop"
+  - else
+    = link_to 'Enable this channel', enable_channel_path(@channel), :confirm => "Enable the channel #{@channel.name}?", :method => :post, :class => "button fplay"
   = link_to 'Delete this channel', @channel, :confirm => "Are you sure you want to delete the channel #{@channel.name}?", :method => :delete, :class => "button fdelete"
 .clear

--- a/app/views/scheduled_calls/_form.html.haml
+++ b/app/views/scheduled_calls/_form.html.haml
@@ -14,7 +14,7 @@
       = f.collection_select :call_flow_id, call_flows, :id, :name, {prompt: 'Select a Call flow...'}, {class: 'w30'}
     %div
       %label Channel
-      = f.collection_select :channel_id, channels, :id, :name, {prompt: 'Select a Channel...'}, {class: 'w30'}
+      = f.collection_select :channel_id, channels, :id, :name_for_combo, {prompt: 'Select a Channel...'}, {class: 'w30'}
     %div
       %label Schedule
       = f.select_recurring :recurrence_rule, [scheduled_call.recurrence_rule], {allow_blank: false}, {:class => 'w30'}

--- a/app/views/shared/_channel_tabs_and_title.haml
+++ b/app/views/shared/_channel_tabs_and_title.haml
@@ -1,7 +1,12 @@
-- if @shared_channel
-  %h1 #{channel.name} (#{channel.kind}, shared as #{@channel_permission})
-- else
-  %h1 #{channel.name} (#{channel.kind})
+%h1
+  = channel.name
+  - if @shared_channel
+    (#{channel.kind}, shared as #{@channel_permission})
+  - else
+    (#{channel.kind})
+  - unless channel.enabled?
+    &mdash;
+    %span.channel-disabled channel disabled
 
 %ul.tabs.top
   %li{ :class =>"#{"active" if params[:controller] == "channels" && params[:action] == 'show'}" }

--- a/broker/include/db.hrl
+++ b/broker/include/db.hrl
@@ -2,7 +2,7 @@
 -record(call_flow, {id, callback_url, broker_flow, project_id, encrypted_config, store_in_fusion_tables, created_at, updated_at}).
 -record(call_log, {id, account_id, project_id, finished_at, direction, address, state, created_at, updated_at, channel_id, started_at, schedule_id, not_before, call_flow_id, pbx_logs_guid, fail_reason, contact_id, fail_code, fail_details}).
 -record(call_log_entry, {id, call_id, severity, details, created_at, updated_at}).
--record(channel, {id, account_id, call_flow_id, name, config, type, created_at, updated_at}).
+-record(channel, {id, account_id, call_flow_id, name, config, type, created_at, updated_at, enabled}).
 -record(contact, {id, project_id, anonymous, created_at, updated_at, last_activity_at}).
 -record(contact_address, {id, address, contact_id, project_id, created_at, updated_at}).
 -record(delayed_job, {id, handler, run_at, created_at, updated_at}).

--- a/broker/src/models/channel.erl
+++ b/broker/src/models/channel.erl
@@ -8,10 +8,10 @@
 -include_lib("erl_dbmodel/include/model.hrl").
 
 find_all_sip() ->
-  find_all({type, in, ["Channels::Sip", "Channels::CustomSip", "Channels::TemplateBasedSip", "Channels::SipServer"]}).
+  find_all([{enabled, 1}, {type, in, ["Channels::Sip", "Channels::CustomSip", "Channels::TemplateBasedSip", "Channels::SipServer"]}]).
 
 find_all_twilio() ->
-  find_all({type, "Channels::Twilio"}).
+  find_all([{enabled, 1}, {type, "Channels::Twilio"}]).
 
 domain(Channel = #channel{type = <<"Channels::TemplateBasedSip">>}) ->
   case proplists:get_value("kind", Channel#channel.config) of

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Verboice::Application.routes.draw do
     resources :queued_calls
     member do
       get :call
+      post :enable
+      post :disable
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,8 @@ Verboice::Application.routes.draw do
         get ":name", :action => "get"
         put ":name", :action => "update"
         delete ":name", :action => "destroy"
+        post ":id/enable", :action => "enable"
+        post ":id/disable", :action => "disable"
       end
     end
     resources :projects, only: [:index, :show] do

--- a/db/migrate/20170124193643_add_enabled_to_channels.rb
+++ b/db/migrate/20170124193643_add_enabled_to_channels.rb
@@ -1,0 +1,5 @@
+class AddEnabledToChannels < ActiveRecord::Migration
+  def change
+    add_column :channels, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161028153200) do
+ActiveRecord::Schema.define(:version => 20170124193643) do
 
   create_table "accounts", :force => true do |t|
     t.string   "email",                               :default => "", :null => false
@@ -121,10 +121,11 @@ ActiveRecord::Schema.define(:version => 20161028153200) do
     t.integer  "call_flow_id"
     t.string   "name"
     t.text     "config"
-    t.datetime "created_at",   :null => false
-    t.datetime "updated_at",   :null => false
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
     t.string   "type"
     t.string   "guid"
+    t.boolean  "enabled",      :default => true
   end
 
   add_index "channels", ["call_flow_id"], :name => "index_channels_on_call_flow_id"

--- a/spec/controllers/api/calls_controller_spec.rb
+++ b/spec/controllers/api/calls_controller_spec.rb
@@ -95,6 +95,12 @@ describe Api::CallsController do
       get :call, :channel => channel.name
       response.should_not be_success
     end
+
+    it "rejects a call using a disabled channel" do
+      channel.disable!
+      get :call, :address => 'foo', :channel_id => channel.id, :callback => 'bar'
+      response.should_not be_success
+    end
   end
 
   it "call state" do

--- a/spec/controllers/api/channels_controller_spec.rb
+++ b/spec/controllers/api/channels_controller_spec.rb
@@ -234,4 +234,40 @@ describe Api::ChannelsController do
       @account.channels.count.should == 0
     end
   end
+
+  describe "enable" do
+    it "should return not found for non existing channel" do
+      post :enable, :id => 1
+      assert_response :not_found
+    end
+
+    it "enables a channel" do
+      chan = Channel.all_leaf_subclasses.sample.make :name => 'foo', :account => @account, :enabled => false
+
+      chan.should_not be_enabled
+
+      post :enable, :id => chan.id
+      assert_response :ok
+
+      chan.reload.should be_enabled
+    end
+  end
+
+  describe "disable" do
+    it "should return not found for non existing channel" do
+      post :enable, :id => 1
+      assert_response :not_found
+    end
+
+    it "disables a channel" do
+      chan = Channel.all_leaf_subclasses.sample.make :name => 'foo', :account => @account
+
+      chan.should be_enabled
+
+      post :disable, :id => chan.id
+      assert_response :ok
+
+      chan.reload.should_not be_enabled
+    end
+  end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -195,6 +195,15 @@ describe ProjectsController do
       flash[:error].should eq('You need to select a Call Flow')
     end
 
+    it 'should fail if the channel is disabled' do
+      channel.disable!
+      expect {
+        post :enqueue_call, :id => project.id, :addresses => "1", :channel_id => channel.id, :schedule_id => schedule.id, :call_flow_id => call_flow.id
+      }.to_not change(QueuedCall, :count).by(1)
+      response.should be_redirect
+      flash[:error].should eq('You need to select a channel')
+    end
+
     it 'should not enqueue multiple calls to the same number' do
       expect {
         post :enqueue_call, :id => project.id, :addresses => "0\n0\n0", :channel_id => channel.id, :schedule_id => schedule.id, :call_flow_id => call_flow.id

--- a/spec/models/scheduled_call_spec.rb
+++ b/spec/models/scheduled_call_spec.rb
@@ -67,6 +67,14 @@ describe ScheduledCall do
       scheduled_call.make_calls from, to
     end
 
+    it "should not make calls if the channel is disabled" do
+      scheduled_call.channel.disable!
+
+      scheduled_call.channel.should_not_receive(:call)
+
+      scheduled_call.make_calls from, to
+    end
+
     describe 'order' do
       before :each do
         @contact_c = Contact.make project: scheduled_call.project


### PR DESCRIPTION
Closes #776 

- Adds a `enabled` field to the `channels` table
- Enable/disable a channel from the channel details page
- Cancel and delete pending queued calls when disabling a channel
- Disallow selecting a disabled channel when enqueueing a call
- For scheduled calls, ignore the calls when the channel is disabled and show the channel as disabled in the selection combo
- Broker ignores disabled channels when building each broker (asterisk, twilio) registry
