### PR TITLE
Don't configure Asterisk channels whose domain name cannot be resolved

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -40,6 +40,10 @@ class Channel < ActiveRecord::Base
 
   broker_cached
 
+  def name=(value)
+    super(value.try(:strip))
+  end
+
   def config
     self[:config] ||= {}
   end

--- a/app/models/channels/sip.rb
+++ b/app/models/channels/sip.rb
@@ -18,12 +18,12 @@
 class Channels::Sip < Channel
   validate :server_username_uniqueness
 
-  config_accessor :username
-  config_accessor :password
-  config_accessor :domain
+  config_accessor :username, strip: true
+  config_accessor :password, strip: true
+  config_accessor :domain, strip: true
   config_accessor :direction
   config_accessor :register
-  config_accessor :number
+  config_accessor :number, strip: true
 
   def register?
     register == true || register == "1"

--- a/broker/src/asterisk/asterisk_config.erl
+++ b/broker/src/asterisk/asterisk_config.erl
@@ -75,89 +75,108 @@ generate_config([Channel | Rest], ConfigFile, ResolvCache, ChannelIndex, Registr
       generate_config(Rest, ConfigFile, ResolvCache, ChannelIndex, RegistryIndex);
 
     _ ->
-      HasAuth = length(Username) > 0 andalso length(Password) > 0,
-      UserOrNumber = case length(Username) > 0 of
-        true -> Username;
-        _ -> Number
-      end,
-
-      % Registration
-      NewRegistryIndex = case channel:register(Channel) of
+      {Expanded, NewCache} = expand_domain(Domain, ResolvCache),
+      % TODO: if we consider the channel's direction (ie. inbound/outbound) we
+      % may relax this condition since we only need a set of resolved IP
+      % addresses to match incoming calls. Although, the domain needs to be
+      % resolvable also if registration is enabled.
+      case is_resolved(Expanded) of
         true ->
+          HasAuth = length(Username) > 0 andalso length(Password) > 0,
+          UserOrNumber = case length(Username) > 0 of
+            true -> Username;
+            _ -> Number
+          end,
+
+          % Registration
+          NewRegistryIndex = case channel:register(Channel) of
+            true ->
+              file:write(ConfigFile, ["[", Section, "]\n"]),
+              file:write(ConfigFile, "type=registration\n"),
+              if HasAuth ->
+                file:write(ConfigFile, ["outbound_auth=", Section, "\n"]);
+                true -> ok
+              end,
+              file:write(ConfigFile, ["server_uri=sip:", Domain, "\n"]),
+              file:write(ConfigFile, ["client_uri=sip:", UserOrNumber, "@", Domain, "\n"]),
+              %% When Asterisk Version > 13.1...
+              % file:write(ConfigFile, "line=yes\n"),
+              % file:write(ConfigFile, ["endpoint=", Section, "\n"]),
+              file:write(ConfigFile, "\n"),
+              dict:store({Username, Domain}, Channel#channel.id, RegistryIndex);
+
+            _ -> RegistryIndex
+          end,
+
+          % Endpoint
           file:write(ConfigFile, ["[", Section, "]\n"]),
-          file:write(ConfigFile, "type=registration\n"),
+          file:write(ConfigFile, "type=endpoint\n"),
+          file:write(ConfigFile, "context=verboice\n"),
+          file:write(ConfigFile, ["aors=", Section, "\n"]),
           if HasAuth ->
             file:write(ConfigFile, ["outbound_auth=", Section, "\n"]);
             true -> ok
           end,
-          file:write(ConfigFile, ["server_uri=sip:", Domain, "\n"]),
-          file:write(ConfigFile, ["client_uri=sip:", UserOrNumber, "@", Domain, "\n"]),
-          %% When Asterisk Version > 13.1...
-          % file:write(ConfigFile, "line=yes\n"),
-          % file:write(ConfigFile, ["endpoint=", Section, "\n"]),
+          file:write(ConfigFile, ["from_user=", UserOrNumber, "\n"]),
+          file:write(ConfigFile, ["from_domain=", Domain, "\n"]),
+          file:write(ConfigFile, "disallow=all\n"),
+          file:write(ConfigFile, "allow=ulaw\n"),
+          file:write(ConfigFile, "allow=gsm\n"),
           file:write(ConfigFile, "\n"),
-          dict:store({Username, Domain}, Channel#channel.id, RegistryIndex);
 
-        _ -> RegistryIndex
-      end,
+          % Auth
+          if HasAuth ->
+            file:write(ConfigFile, ["[", Section, "]\n"]),
+            file:write(ConfigFile, "type=auth\n"),
+            file:write(ConfigFile, "auth_type=userpass\n"),
+            file:write(ConfigFile, ["username=", Username, "\n"]),
+            file:write(ConfigFile, ["password=", Password, "\n"]),
+            file:write(ConfigFile, "\n");
+            true -> ok
+          end,
 
-      % Endpoint
-      file:write(ConfigFile, ["[", Section, "]\n"]),
-      file:write(ConfigFile, "type=endpoint\n"),
-      file:write(ConfigFile, "context=verboice\n"),
-      file:write(ConfigFile, ["aors=", Section, "\n"]),
-      if HasAuth ->
-        file:write(ConfigFile, ["outbound_auth=", Section, "\n"]);
-        true -> ok
-      end,
-      file:write(ConfigFile, ["from_user=", UserOrNumber, "\n"]),
-      file:write(ConfigFile, ["from_domain=", Domain, "\n"]),
-      file:write(ConfigFile, "disallow=all\n"),
-      file:write(ConfigFile, "allow=ulaw\n"),
-      file:write(ConfigFile, "allow=gsm\n"),
-      file:write(ConfigFile, "\n"),
+          % AOR
+          file:write(ConfigFile, ["[", Section, "]\n"]),
+          file:write(ConfigFile, "type=aor\n"),
+          file:write(ConfigFile, "qualify_frequency=60\n"),
+          file:write(ConfigFile, ["contact=sip:", Domain, "\n"]),
+          file:write(ConfigFile, "\n"),
 
-      % Auth
-      if HasAuth ->
-        file:write(ConfigFile, ["[", Section, "]\n"]),
-        file:write(ConfigFile, "type=auth\n"),
-        file:write(ConfigFile, "auth_type=userpass\n"),
-        file:write(ConfigFile, ["username=", Username, "\n"]),
-        file:write(ConfigFile, ["password=", Password, "\n"]),
-        file:write(ConfigFile, "\n");
-        true -> ok
-      end,
+          % Identify
+          file:write(ConfigFile, ["[", Section, "]\n"]),
+          file:write(ConfigFile, "type=identify\n"),
+          file:write(ConfigFile, ["endpoint=", Section, "\n"]),
 
-      % AOR
-      file:write(ConfigFile, ["[", Section, "]\n"]),
-      file:write(ConfigFile, "type=aor\n"),
-      file:write(ConfigFile, "qualify_frequency=60\n"),
-      file:write(ConfigFile, ["contact=sip:", Domain, "\n"]),
-      file:write(ConfigFile, "\n"),
+          {NewChannelIndex, _} = lists:foldl(fun ({_Host, IPs, Port}, {R1, I}) ->
+            case Port of
+              undefined -> ok;
+              _ -> ok
+                % file:write(ConfigFile, ["port=", integer_to_list(Port), "\n"])
+            end,
 
-      % Identify
-      file:write(ConfigFile, ["[", Section, "]\n"]),
-      file:write(ConfigFile, "type=identify\n"),
-      file:write(ConfigFile, ["endpoint=", Section, "\n"]),
+            R3 = lists:foldl(fun (IP, R2) ->
+              file:write(ConfigFile, ["match=", IP, "\n"]),
+              dict:append({util:to_string(IP), Number}, Channel#channel.id, R2)
+            end, R1, IPs),
+            {R3, I + 1}
+          end, {ChannelIndex, 0}, Expanded),
+          file:write(ConfigFile, "\n"),
 
-      {Expanded, NewCache} = expand_domain(Domain, ResolvCache),
-      {NewChannelIndex, _} = lists:foldl(fun ({_Host, IPs, Port}, {R1, I}) ->
-        case Port of
-          undefined -> ok;
-          _ -> ok
-            % file:write(ConfigFile, ["port=", integer_to_list(Port), "\n"])
-        end,
+          generate_config(Rest, ConfigFile, NewCache, NewChannelIndex, NewRegistryIndex);
 
-        R3 = lists:foldl(fun (IP, R2) ->
-          file:write(ConfigFile, ["match=", IP, "\n"]),
-          dict:append({util:to_string(IP), Number}, Channel#channel.id, R2)
-        end, R1, IPs),
-        {R3, I + 1}
-      end, {ChannelIndex, 0}, Expanded),
-      file:write(ConfigFile, "\n"),
-
-      generate_config(Rest, ConfigFile, NewCache, NewChannelIndex, NewRegistryIndex)
+        false ->
+          % Domain could not be resolved, we cannot generate the endpoint
+          % information for Asterisk
+          generate_config(Rest, ConfigFile, NewCache, ChannelIndex, RegistryIndex)
+      end
   end.
+
+is_resolved([]) ->
+  false;
+is_resolved([{_Host, [_Ip|_], _Port}|_]) ->
+  true;
+is_resolved([_|Rest]) ->
+  is_resolved(Rest).
 
 expand_domain(<<>>, ResolvCache) -> {[], ResolvCache};
 expand_domain(Domain, ResolvCache) ->
@@ -191,7 +210,7 @@ expand_domain(Domain) ->
         {ok, #hostent{h_addr_list = IpList}} ->
           IPs = map_ips(IpList),
           [{Domain, IPs, undefined}];
-        _ -> [{Domain, [Domain], undefined}]
+        _ -> [{Domain, [], undefined}]
       end
   end.
 

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -19,6 +19,7 @@ class ActiveRecord::Base
   def self.config_accessor(*names)
     options = names.extract_options!
     default = options[:default]
+    strip = options[:strip]
 
     names.each do |name|
       self.config_attrs << name
@@ -31,6 +32,7 @@ class ActiveRecord::Base
         respond_to?(:encrypted_config_will_change!) ? encrypted_config_will_change! : config_will_change!
 
         self.config ||= {}
+        value = value.try(:strip) if strip
         self.config[name.to_s] = value
 
         # this is needed so attr_encrypted encrypts the value correctly


### PR DESCRIPTION
Fixes #783 

If the broker fails to resolve the domain name for a SIP channel, do not write the channel in the Asterisk configuration file.

**There is a major caveat to this approach**: if there is a transient DNS outage when regenerating the configuration, most (all?) channels will not be configured in Asterisk. Then again, in that case we cannot write a "good" configuration file at all.

Under normal circumstances, the name resolution fails due to a typo/extra whitespace in the user entered domain. We strip the domain name, username and passwords in the UI to alleviate this problem. Also, if the DNS query fails, the error is reported back to the UI for the user to see in the channels list.

Strictly speaking, we only need the resolved IP addresses for the `identify` sections of PJSIP. If we don't have them, then Asterisk cannot identify an incoming call by matching the IP address to the originating domain, but it can be configured to perform SRV lookups or make the identification based on the `From:` header. See https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Configuration_res_pjsip_endpoint_identifier_ip and https://wiki.asterisk.org/wiki/display/AST/PJSIP+Configuration+Sections+and+Relationships#PJSIPConfigurationSectionsandRelationships-SectionTypes.

If the channel is configured for registration, the domain name also needs to resolve to perform the registration.
