### PR TITLE
Fix error condition handling in failed calls

### DIFF
--- a/broker/src/twilio/twilio_broker.erl
+++ b/broker/src/twilio/twilio_broker.erl
@@ -39,7 +39,7 @@ dispatch(_Session = #session{session_id = SessionId, channel = Channel, address 
   lager:info("Twilio response: ~p~n", [Response]),
   case Response of
     {ok, {{_, 201, _}, _, _}} -> ok;
-    {ok, {{_, _, Reason}, _, Msg}} -> {error, parse_exception(Reason, Msg)};
+    {ok, {{_, _, Reason}, _, Msg}} -> parse_exception(Reason, Msg);
     _ ->
       timer:apply_after(timer:minutes(1), broker, notify_ready, [?MODULE]),
       {error, unavailable}
@@ -56,5 +56,5 @@ parse_exception(Reason, Body) ->
     [Message] = xmerl_xs:value_of(xmerl_xs:select("./Message", Exception)),
     {error, Message, FullCode}
   catch
-    _ -> Reason
+    _ -> {error, Reason}
   end.


### PR DESCRIPTION
Fixes #778

- Fix returned value from twilio_broker:dispatch in case of a HTTP error
  reported by the server.
- Change failure code during the session execution for internal/fatal errors to
  make them apart from errors reported from twilio_broker. All errors caused by
  unhandled exceptions or processes dying are now labeled as internal_error and
  the reason correctly rendered into a string to save to the database.