### PR TITLE
Fix #780: don't crash if a queued call flow is invalid

### DIFF
--- a/broker/src/models/queued_call.erl
+++ b/broker/src/models/queued_call.erl
@@ -1,4 +1,5 @@
 -module(queued_call).
+-compile([{parse_transform, lager_transform}]).
 -export([reschedule/1, start_session/1]).
 -define(TABLE_NAME, "queued_calls").
 -include("session.hrl").
@@ -35,7 +36,17 @@ start_session(QueuedCall = #queued_call{call_flow_id = CallFlowId}) when is_numb
 start_session(QueuedCall = #queued_call{callback_url = CallbackUrl}) when is_binary(CallbackUrl) ->
   start_session(#session{flow = flow:callback_flow(CallbackUrl)}, QueuedCall);
 start_session(QueuedCall = #queued_call{flow = Flow}) ->
-  start_session(#session{flow = twiml:parse(Flow)}, QueuedCall).
+  ParsedFlow = try
+                 twiml:parse(Flow)
+               catch
+                 %% If we fail to parse the flow, simply return undefined;
+                 %% the session will finalize with status of failed and an
+                 %% appropriate error message.
+                 _:_ ->
+                   lager:warning("Failed to parse TwiML flow: ~p", [Flow]),
+                   undefined
+               end,
+  start_session(#session{flow = ParsedFlow}, QueuedCall).
 
 start_session(Session, QueuedCall) ->
   Project = project:find(QueuedCall#queued_call.project_id),

--- a/broker/test/queued_call_test.erl
+++ b/broker/test/queued_call_test.erl
@@ -43,3 +43,31 @@ start_session_with_flow_test() ->
   ?assertEqual(twiml:parse(QueuedCall#queued_call.flow), Session#session.flow),
 
   meck:unload().
+
+%% Test case for #780
+start_session_with_invalid_flow_test() ->
+  QueuedCall = #queued_call{flow = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Say voice=\"woman\">Hello.</Say>\n</Hangup>", project_id = project_id},
+  meck:new(project),
+  meck:expect(project, find, [project_id], #project{}),
+  meck:expect(project, status_callback, 1, {undefined, undefined, undefined, false}),
+
+  Session = queued_call:start_session(QueuedCall),
+
+  ?assertEqual(undefined, Session#session.call_flow),
+  ?assertEqual(undefined, Session#session.flow),
+
+  meck:unload().
+
+%% Test case for #780
+start_session_with_invalid_xml_flow_test() ->
+  QueuedCall = #queued_call{flow = "<Response>\n  <Gather numDigits=\"1\" action=\"http://twimlets.com/voicemail?Email=nicp%40textit.in&Message=https%3A%2F%2example.com%2F/voicemail.wav&Transcribe=false\">\n    <Say language=\"en\">Pick a number, zero through nine.</Say>\n  </Gather>\n</Response>", project_id = project_id},
+  meck:new(project),
+  meck:expect(project, find, [project_id], #project{}),
+  meck:expect(project, status_callback, 1, {undefined, undefined, undefined, false}),
+
+  Session = queued_call:start_session(QueuedCall),
+
+  ?assertEqual(undefined, Session#session.call_flow),
+  ?assertEqual(undefined, Session#session.flow),
+
+  meck:unload().


### PR DESCRIPTION
Improve handling of an invalid flow in a queued call, catching exceptions and
yielding an undefined flow to be later handled appropriately. Previously,
`twiml:parse/1` would crash terminating the `channel_queue` process. This would
lead to outstanding queued calls in the database and inability to continue
processing any other queued calls in the channel.