### PR TITLE
Fix #797: Merge query string params when performing status callback

### DIFF
--- a/broker/src/session/session.erl
+++ b/broker/src/session/session.erl
@@ -311,7 +311,9 @@ notify_status_to_callback_url(Status, Session = #session{call_log = CallLog, add
           <<>> -> [];
           User -> [{basic_auth, {User, Session#session.status_callback_password}}]
         end,
-        (Uri#uri{query_string = QueryString}):get([{full_result, false} | AuthOptions])
+        MergedQueryString = Uri#uri.query_string ++ QueryString,
+        NewUri = Uri#uri{query_string = MergedQueryString},
+        NewUri:get([{full_result, false} | AuthOptions])
       end)
   end.
 

--- a/broker/test/session_test.erl
+++ b/broker/test/session_test.erl
@@ -77,3 +77,16 @@ notify_status_on_completed_with_session_vars_test() ->
 
   meck:wait(httpc, request, RequestParams, 1000),
   meck:unload().
+
+notify_status_merges_query_string_test() ->
+  Session = #session{address = <<"123">>, call_log = {call_log_srv}, status_callback_url = <<"http://foo.com?sample=1">>},
+  meck:new(call_log_srv, [stub_all]),
+  meck:expect(call_log_srv, id, 1, 1),
+  meck:new(httpc),
+
+  RequestParams = [get, {"http://foo.com/?sample=1&CallSid=1&CallStatus=completed&From=123&CallDuration=0", []}, '_', [{full_result, false}]],
+  meck:expect(httpc, request, RequestParams, ok),
+  session:in_progress({completed, Session, ok}, #state{session = Session}),
+
+  meck:wait(httpc, request, RequestParams, 1000),
+  meck:unload().


### PR DESCRIPTION
When performing the status callback for a call, preserve the query string
parameters which may have been present in the configured URL, and merge the call
and session variables.