### PR TITLE
API: cancel a call

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,11 +127,11 @@ Verboice::Application.routes.draw do
 
   namespace :api do
     match "call" => "calls#call"
-    resources :calls, only: [] do
+    resources :calls, only: [:destroy] do
       member do
         match :state
         match :redirect
-        get :details
+        match :cancel
       end
     end
     get "channels" => "channels#list"

--- a/spec/controllers/api/calls_controller_spec.rb
+++ b/spec/controllers/api/calls_controller_spec.rb
@@ -111,4 +111,21 @@ describe Api::CallsController do
     result['call_id'].should == call_log.id
     result['state'].should == call_log.state.to_s
   end
+
+  it "cancells a call" do
+    project = Project.make account: @controller.current_account
+    call_log = CallLog.make :call_flow => CallFlow.make(project: project)
+    queued_call = QueuedCall.make :call_log => call_log
+
+    post :cancel, :id => call_log.id
+
+    result = JSON.parse(@response.body)
+    result['call_id'].should eq(call_log.id)
+    result['state'].should eq('canceled')
+
+    call_log = CallLog.find_by_id(call_log.id)
+    call_log.state.should eq(:canceled)
+
+    QueuedCall.find_by_id(queued_call.id).should be_nil
+  end
 end


### PR DESCRIPTION
- The endpoint is `POST /api/calls/:id/cancel`
- All queued calls for the call log are deleted
- The call log is marked as "failed" (I didn't use "canceled" because I couldn't find this state in the code, only in a Twilio handler, but I don't know if this could break some other code that depends on states being a fixed set that, so far, didn't include "canceled")

Needed for https://github.com/instedd/ask/issues/653