### PR TITLE
Set a non-anonymous CallerID for calls

### DIFF
--- a/broker/src/asterisk/asterisk_broker.erl
+++ b/broker/src/asterisk/asterisk_broker.erl
@@ -51,5 +51,6 @@ dispatch(#session{session_id = SessionId, channel = Channel, address = Address})
     {async, true},
     {actionid, SessionId},
     {timeout, 60000},
-    {variable, ["verboice_session_id=", SessionId]}
+    {variable, ["verboice_session_id=", SessionId]},
+    {callerId, ["<", channel:number(Channel), ">"]}
   ]).


### PR DESCRIPTION
Use the channel's number to set a non-"Anonymous" From: header.

The From header used to look like this:

```
From: "Anonymous" <sip:0123456789@123.123.123.123>;tag=9620a5a1-1948-45d5-a223-c0b7c251b029
```

Now they look like this:

```
From: <sip:0123456789@123.123.123.123>;tag=9620a5a1-1948-45d5-a223-c0b7c251b029
```

This proved to be relevant with some telcos out there.

Co-authored-by: Juan Wajnerman <jwajnerman@manas.com.ar>
Co-authored-by: Gustavo Giráldez <ggiraldez@manas.com.ar>