### PR TITLE
Add record option to transfer step

### DIFF
--- a/app/assets/javascripts/workflow/steps/transfer_step.js.coffee
+++ b/app/assets/javascripts/workflow/steps/transfer_step.js.coffee
@@ -10,10 +10,12 @@ onWorkflow ->
       @next_id = attrs.next
       @address = ko.observable attrs.address
       @channel = ko.observable attrs.channel
-      
+
       @successful_after_check = ko.observable(_.isString(attrs.successful_after))
       @successful_after_input = ko.observable(attrs.successful_after or "")
       @successful_after = ko.computed () => if @successful_after_check() then @successful_after_input() else null
+
+      @record_call = ko.observable(attrs.record_call)
 
       @is_address_invalid = ko.computed () =>
         not @address()
@@ -39,6 +41,7 @@ onWorkflow ->
         address: @address()
         channel: @channel()
         successful_after: @successful_after()
+        record_call: @record_call()
       )
 
     default_name: () =>

--- a/app/models/parsers/user_flow_node/transfer.rb
+++ b/app/models/parsers/user_flow_node/transfer.rb
@@ -30,6 +30,7 @@ module Parsers
         @next = params['next']
         @root_index = params['root']
         @successful_after = params['successful_after']
+        @record_call = params['record_call']
       end
 
       def is_root?

--- a/app/views/call_flows/_transfer_step_template.haml
+++ b/app/views/call_flows/_transfer_step_template.haml
@@ -41,6 +41,11 @@
               %li 10 seconds
               %li 2 minutes
               %li 1 hour
+      .content
+        %hr
+        %input{ type: 'checkbox', 'data-bind' => 'checked: record_call, attr: { id: ("record_call_" + id) }' }
+        %label{ title: 'When checked, the forwarded call will be recorded.', 'data-bind' => 'attr: { for: ("record_call_" + id) }'} Record call
+        %br
 
       .bottom-actions
         = render partial: 'bottom_actions'


### PR DESCRIPTION
This is how the new option looks in the call flow designer:

![image](https://user-images.githubusercontent.com/39921597/78247939-1e5b5180-74c2-11ea-92d6-8651b28e3781.png)

What I've tested:

1. Reloading the page after saving will honor the user selection for the new option -> it's persisted in the DB.
2. Exporting and importing a call flow will honor the user selection for the new option -> it's persisted in the `.vrb` file.

Fix #854