### PR TITLE
Recording playback from call log view

### DIFF
--- a/app/assets/stylesheets/call_logs.scss
+++ b/app/assets/stylesheets/call_logs.scss
@@ -17,6 +17,10 @@
 }
 
 .call-log-header {
+  .item {
+    padding-bottom: 18px;
+    font-size: 16px;
+  }
   a.call-log-fail-info {
     text-decoration: underline;
   }
@@ -28,6 +32,9 @@
     span {
       word-wrap: break-word;
     }
+  }
+  tr {
+    height: 48px;
   }
 }
 

--- a/app/assets/stylesheets/theme-extra.scss
+++ b/app/assets/stylesheets/theme-extra.scss
@@ -176,7 +176,7 @@ ul.call-log-details li div span.grey { color:#999999 }
 ul.call-log-details li.orange div { background-position:left -48px }
 ul.call-log-details li.orange div span { color:#ff6600 }
 
-.user-flow-log {
+.call-log {
   min-height: 0px;
   padding: 0px;
   width: 800px;
@@ -208,6 +208,17 @@ ul.call-log-details li.orange div span { color:#ff6600 }
       }
     }
   }
+}
+
+.call-log-attachtments {
+  @extend .call-log;
+  .description {
+    color: #999999;
+  }
+}
+
+.user-flow-log {
+  @extend .call-log;
 }
 
 .butt-right { background: url(http://theme.instedd.org/theme/images/buttons/mark/greyRight.png) no-repeat right top; color:#000000 !important; padding:2px 15px 2px 4px; display:inline-block; vertical-align:middle }

--- a/app/models/call_log.rb
+++ b/app/models/call_log.rb
@@ -25,6 +25,7 @@ class CallLog < ActiveRecord::Base
   has_many :traces, :foreign_key => 'call_id'
   has_many :entries, :foreign_key => 'call_id', :class_name => "CallLogEntry"
   has_many :pbx_logs, :foreign_key => :guid, :primary_key => :pbx_logs_guid
+  has_many :recorded_audios, :foreign_key => 'call_log_id'
 
   scope :for_account, ->(account) {
     joins(:channel).where('call_logs.project_id IN (?) OR call_logs.account_id = ? OR channels.account_id = ?', account.readable_project_ids, account.id, account.id)

--- a/app/views/call_logs/show.haml
+++ b/app/views/call_logs/show.haml
@@ -39,10 +39,34 @@
     .item
       %b Failure information:
       = call_log_fail_info(@log)
-%br/
-%p
-  = link_to 'Download CSV', download_details_call_log_path(@log, :format => :csv), :class => "button fimport"
 
+- if @log.recorded_audios
+  %br
+  %h3 Attachments
+  .tablewrapp.call-log-attachtments
+    %table
+      %tr
+        %td.description
+          CSV
+        %td.icon
+          %div.i48grad-dataBase
+        %td
+        %td.details
+          = link_to 'Download', download_details_call_log_path(@log, :format => :csv), :class => "button fimport"
+      -@log.recorded_audios.each do |recorded_audio|
+        %tr
+          %td.description
+            = recorded_audio.description
+          %td.icon
+            %div.i48grad-sound
+          %td
+            %audio{controls: true, controlsList: "nodownload"}
+              %source{src: result_call_log_path(@log, :key => recorded_audio.key), type: "audio/mpeg"}
+          %td.details
+            = link_to 'Download', result_call_log_path(@log, :key => recorded_audio.key), :class => "button fimport"
+
+%br
+%h3 Workflow logs
 .tablewrapp.user-flow-log
   %table
     -@activities.each do |activity|
@@ -62,7 +86,7 @@
             = activity.fields['step_data']
 
 - if @log.pbx_logs_guid
-  %br/
+  %br
   %h3 Network Logs
   %table.GralTable.PbxLogTable
     %tr
@@ -74,4 +98,3 @@
         %td.call-log-pbx-details
           %span= pbx_log.details
   %br
-

--- a/app/views/call_logs/show.haml
+++ b/app/views/call_logs/show.haml
@@ -40,33 +40,32 @@
       %b Failure information:
       = call_log_fail_info(@log)
 
-- if @log.recorded_audios
-  %br
-  %h3 Attachments
-  .tablewrapp.call-log-attachtments
-    %table
+%br
+%h3 Attachments
+.tablewrapp.call-log-attachtments
+  %table
+    %tr
+      %td.description
+        CSV
+      %td.icon
+        %div.i48grad-dataBase
+      %td
+      %td.details
+        = link_to 'Download', download_details_call_log_path(@log, :format => :csv), :class => "button fimport"
+    -@log.recorded_audios.each do |recorded_audio|
       %tr
         %td.description
-          CSV
+          = recorded_audio.description
         %td.icon
-          %div.i48grad-dataBase
+          %div.i48grad-sound
         %td
+          %audio{controls: true, controlsList: "nodownload"}
+            %source{src: result_call_log_path(@log, :key => recorded_audio.key), type: "audio/mpeg"}
         %td.details
-          = link_to 'Download', download_details_call_log_path(@log, :format => :csv), :class => "button fimport"
-      -@log.recorded_audios.each do |recorded_audio|
-        %tr
-          %td.description
-            = recorded_audio.description
-          %td.icon
-            %div.i48grad-sound
-          %td
-            %audio{controls: true, controlsList: "nodownload"}
-              %source{src: result_call_log_path(@log, :key => recorded_audio.key), type: "audio/mpeg"}
-          %td.details
-            = link_to 'Download', result_call_log_path(@log, :key => recorded_audio.key), :class => "button fimport"
+          = link_to 'Download', result_call_log_path(@log, :key => recorded_audio.key), :class => "button fimport"
 
 %br
-%h3 Workflow logs
+%h3 Workflow Logs
 .tablewrapp.user-flow-log
   %table
     -@activities.each do |activity|


### PR DESCRIPTION
This is how the new attachment table (with recording player) looks:

![Call log screen](https://user-images.githubusercontent.com/39921597/78721452-f888df00-78fd-11ea-9771-7c026fe1eaac.png)

Fix #857