### PR TITLE
Persist forwarded calls recordings when caller hangs

### DIFF
--- a/broker/src/commands/dial.erl
+++ b/broker/src/commands/dial.erl
@@ -43,7 +43,6 @@ run(Args, Session = #session{pbx = Pbx, channel = CurrentChannel, js_context = J
 
   try
     Result = Pbx:dial(Channel, Number, CallerId, LocalFilename, AsteriskFilename),
-    persist_recording(AsteriskFilename, [Contact, Project, CallLog:id(), Key, Description]),
     ResultJS = erjs_context:set(dial_status, Result, JS),
     NewJS = maybe_mark_session_successful(DialStart, SuccessAfterSeconds, ResultJS),
 
@@ -53,6 +52,8 @@ run(Args, Session = #session{pbx = Pbx, channel = CurrentChannel, js_context = J
     hangup ->
       UpdatedJS = maybe_mark_session_successful(DialStart, SuccessAfterSeconds, JS),
       throw({hangup, Session#session{js_context = UpdatedJS}})
+  after
+    persist_recording(AsteriskFilename, [Contact, Project, CallLog:id(), Key, Description])
   end.
 
 persist_recording(undefined, _) -> undefined;


### PR DESCRIPTION
If the caller hangs the call during a forwarding, we want to
keep the recording anyway.

See #860
See #859