### PR TITLE
Unify `cancelled` and `canceled` call states

### DIFF
--- a/app/controllers/api/calls_controller.rb
+++ b/app/controllers/api/calls_controller.rb
@@ -101,7 +101,7 @@ module Api
         qc.destroy
       end
 
-      call_log.state = "canceled"
+      call_log.state = "cancelled"
       call_log.save!
 
       render :json => {

--- a/app/controllers/queued_calls_controller.rb
+++ b/app/controllers/queued_calls_controller.rb
@@ -23,6 +23,6 @@ class QueuedCallsController < ApplicationController
     @call.cancel_call!
     @call.destroy
 
-    redirect_to(call_logs_path, :notice => "Call to #{@call.address} successfully canceled.")
+    redirect_to(call_logs_path, :notice => "Call to #{@call.address} successfully cancelled.")
   end
 end

--- a/broker/src/africas_talking/africas_talking_pbx.erl
+++ b/broker/src/africas_talking/africas_talking_pbx.erl
@@ -129,7 +129,7 @@ handle_call({resume, Params}, From, State = #state{session = Session, waiting = 
     "busy" -> busy;
     "no-answer" -> no_answer;
     "failed" -> failed;
-    "canceled" -> canceled;
+    "canceled" -> cancelled;
     Other ->
       lager:warning("Unknown DialCallStatus: ~p", [Other]),
       failed

--- a/broker/src/twilio/twilio_pbx.erl
+++ b/broker/src/twilio/twilio_pbx.erl
@@ -122,7 +122,7 @@ handle_call({resume, Params}, From, State = #state{session = Session, waiting = 
     "busy" -> busy;
     "no-answer" -> no_answer;
     "failed" -> failed;
-    "canceled" -> canceled;
+    "canceled" -> cancelled;
     Other ->
       lager:warning("Unknown DialCallStatus: ~p", [Other]),
       failed

--- a/db/migrate/20200420224723_unify_cancelled_and_cancelled_call_states.rb
+++ b/db/migrate/20200420224723_unify_cancelled_and_cancelled_call_states.rb
@@ -1,0 +1,13 @@
+class UnifyCancelledAndCancelledCallStates < ActiveRecord::Migration
+  def up
+    ActiveRecord::Base.connection.execute <<-SQL
+      UPDATE `call_logs`
+      SET `state` = "cancelled"
+      WHERE `state` = "canceled"
+    SQL
+  end
+
+  def down
+    # Nothing to do - can't revert the change
+  end
+end

--- a/db/migrate/20200420225523_remove_deprecated_suspended_call_log_state.rb
+++ b/db/migrate/20200420225523_remove_deprecated_suspended_call_log_state.rb
@@ -1,0 +1,13 @@
+class RemoveDeprecatedSuspendedCallLogState < ActiveRecord::Migration
+  def up
+    ActiveRecord::Base.connection.execute <<-SQL
+      UPDATE `call_logs`
+      SET `state` = "cancelled", `fail_reason` = "Call was kept in a deprecated 'suspended' state"
+      WHERE `state` = "suspended"
+    SQL
+  end
+
+  def down
+    # Nothing to do - can't revert the change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20171211152836) do
+ActiveRecord::Schema.define(:version => 20200420225523) do
 
   create_table "accounts", :force => true do |t|
     t.string   "email",                               :default => "", :null => false

--- a/spec/controllers/api/calls_controller_spec.rb
+++ b/spec/controllers/api/calls_controller_spec.rb
@@ -124,10 +124,10 @@ describe Api::CallsController do
 
     result = JSON.parse(@response.body)
     expect(result['call_id']).to eq(call_log.id)
-    expect(result['state']).to eq('canceled')
+    expect(result['state']).to eq('cancelled')
 
     call_log = CallLog.find_by_id(call_log.id)
-    expect(call_log.state).to eq(:canceled)
+    expect(call_log.state).to eq(:cancelled)
 
     expect(QueuedCall.find_by_id(queued_call.id)).to be_nil
   end


### PR DESCRIPTION
Also migrates old `suspended` states.

Fixes #872