### PR TITLE
Fix: Contact's don't have `finished_at` but `last_activity_at`

### DIFF
--- a/app/models/call_log.rb
+++ b/app/models/call_log.rb
@@ -85,7 +85,7 @@ class CallLog < ActiveRecord::Base
     self.finished_at = Time.now.utc
     self.save!
 
-    self.contact.update_column(:last_activity_at, self.finished_at) if self.contact && self.finished_at > self.contact.finished_at
+    self.contact.update_column(:last_activity_at, self.finished_at) if self.contact && (self.contact.last_activity_at.nil? || self.finished_at > self.contact.last_activity_at)
 
     begin
       call_flow.try(:push_results, self) if call_flow && call_flow.store_in_fusion_tables


### PR DESCRIPTION
The buggy code was introduced in 10a0666709e1f96f2f4e527ca977e15fc62a087f for #741. It seems it never worked as intended - probably because the calls usually are finished by the broker instead of the web.