### PR TITLE
Add base url setting to twilio channels

### DIFF
--- a/app/controllers/channels_ui_controller.rb
+++ b/app/controllers/channels_ui_controller.rb
@@ -106,7 +106,8 @@ class ChannelsUiController < ApplicationController
           auth_token: @channel.auth_token,
           number: @channel.number,
           limit: @channel.limit,
-          errors: @channel.errors
+          errors: @channel.errors,
+          base_url: @channel.base_url
         })
 
       when "africas_talking"
@@ -149,6 +150,7 @@ class ChannelsUiController < ApplicationController
       @channel.auth_token = params[:config][:auth_token]
       @channel.number = params[:config][:number]
       @channel.limit = params[:config][:limit]
+      @channel.base_url = params[:config][:base_url]
     when "africas_talking"
       @channel.name = params[:config][:name]
       @channel.username = params[:config][:username]

--- a/app/models/channels/twilio.rb
+++ b/app/models/channels/twilio.rb
@@ -19,10 +19,13 @@ class Channels::Twilio < Channel
   config_accessor :account_sid
   config_accessor :auth_token
   config_accessor :number
+  config_accessor :base_url
 
   attr_protected :guid
 
   before_create :create_guid
+
+  validates :base_url, format: URI::regexp(["http", "https"]), allow_nil: true, allow_blank: true
 
   def create_guid
     self.guid ||= Guid.new.to_s

--- a/app/views/channels/_form_twilio.haml
+++ b/app/views/channels/_form_twilio.haml
@@ -10,3 +10,6 @@
 .field
   = f.label :limit
   = f.text_field :limit, readonly: readonly
+.field
+  = f.label :base_url
+  = f.text_field :base_url, readonly: readonly

--- a/app/views/channels_ui/_form_twilio.haml
+++ b/app/views/channels_ui/_form_twilio.haml
@@ -9,3 +9,6 @@
 
 .row
   = f.text_field :limit, colspan: 's4', helper: 'Number of concurrent calls'
+
+.row
+  = f.text_field :base_url, label: 'Twilio base URL'

--- a/broker/include/config_methods.hrl
+++ b/broker/include/config_methods.hrl
@@ -25,6 +25,7 @@
 ?METHOD_TPL(guisso_url).
 ?METHOD_TPL(broker_httpd_base_url).
 ?METHOD_TPL(twilio_callback_url).
+?METHOD_TPL(twilio_base_url).
 ?METHOD_TPL(hub_enabled).
 ?METHOD_TPL(hub_url).
 

--- a/broker/src/africas_talking/africas_talking_api.erl
+++ b/broker/src/africas_talking/africas_talking_api.erl
@@ -9,7 +9,7 @@ incoming_phone_numbers(Channel) ->
 incoming_phone_numbers(Channel, PhoneNumber) ->
   AccountSid = channel:account_sid(Channel),
   AuthToken = channel:auth_token(Channel),
-  RequestUrl = "https://api.twilio.com/2010-04-01/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
+  RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
   RequestUri = uri:parse(RequestUrl),
   case uri:get([{basic_auth, {AccountSid, AuthToken}}], RequestUri#uri{query_string = [{'PhoneNumber', PhoneNumber}]}) of
     {ok, {{_, 200, _}, _, Body}} -> {ok, {Data}} = json:decode(Body), {ok, Data};
@@ -23,7 +23,7 @@ update_voice_url(Channel, PhoneNumber) ->
     {ok, PhoneSid} ->
       AccountSid = channel:account_sid(Channel),
       AuthToken = channel:auth_token(Channel),
-      RequestUrl = "https://api.twilio.com/2010-04-01/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
+      RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
       TwilioCallbackUrl = verboice_config:twilio_callback_url(),
       RequestBody = [{'VoiceUrl', list_to_binary(TwilioCallbackUrl)}],
       uri:post_form(RequestBody, [{basic_auth, {AccountSid, AuthToken}}], RequestUrl),

--- a/broker/src/models/channel.erl
+++ b/broker/src/models/channel.erl
@@ -5,7 +5,7 @@
          broker/1, is_outbound/1, limit/1, register/1,
          log_broken_channels/2,
          disable_by_id/1, disable_by_ids/1,
-         account_sid/1, auth_token/1, api_key/1]).
+         account_sid/1, auth_token/1, api_key/1, base_url/1]).
 
 -define(CACHE, true).
 -define(TABLE_NAME, "channels").
@@ -49,6 +49,17 @@ auth_token(#channel{config = Config}) ->
 
 api_key(#channel{config = Config}) ->
   proplists:get_value("api_key", Config).
+
+base_url(#channel{type = <<"Channels::Twilio">>, config = Config}) ->
+  BaseUrl = proplists:get_value("base_url", Config),
+  FallbackUrl = verboice_config:twilio_base_url(),
+  case BaseUrl of
+    nil -> FallbackUrl;
+    "" -> FallbackUrl;
+    _ -> BaseUrl
+  end;
+
+base_url(_) -> nil.
 
 is_outbound(#channel{type = <<"Channels::TemplateBasedSip">>}) ->
   true;

--- a/broker/src/twilio/twilio_api.erl
+++ b/broker/src/twilio/twilio_api.erl
@@ -9,7 +9,7 @@ incoming_phone_numbers(Channel) ->
 incoming_phone_numbers(Channel, PhoneNumber) ->
   AccountSid = channel:account_sid(Channel),
   AuthToken = channel:auth_token(Channel),
-  RequestUrl = "https://api.twilio.com/2010-04-01/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
+  RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
   RequestUri = uri:parse(RequestUrl),
   case uri:get([{basic_auth, {AccountSid, AuthToken}}], RequestUri#uri{query_string = [{'PhoneNumber', PhoneNumber}]}) of
     {ok, {{_, 200, _}, _, Body}} -> {ok, {Data}} = json:decode(Body), {ok, Data};
@@ -23,7 +23,7 @@ update_voice_url(Channel, PhoneNumber) ->
     {ok, PhoneSid} ->
       AccountSid = channel:account_sid(Channel),
       AuthToken = channel:auth_token(Channel),
-      RequestUrl = "https://api.twilio.com/2010-04-01/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
+      RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
       TwilioCallbackUrl = verboice_config:twilio_callback_url(),
       RequestBody = [{'VoiceUrl', list_to_binary(TwilioCallbackUrl)}],
       uri:post_form(RequestBody, [{basic_auth, {AccountSid, AuthToken}}], RequestUrl),

--- a/broker/src/twilio/twilio_api.erl
+++ b/broker/src/twilio/twilio_api.erl
@@ -9,7 +9,7 @@ incoming_phone_numbers(Channel) ->
 incoming_phone_numbers(Channel, PhoneNumber) ->
   AccountSid = channel:account_sid(Channel),
   AuthToken = channel:auth_token(Channel),
-  RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
+  RequestUrl = channel:base_url(Channel) ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers.json",
   RequestUri = uri:parse(RequestUrl),
   case uri:get([{basic_auth, {AccountSid, AuthToken}}], RequestUri#uri{query_string = [{'PhoneNumber', PhoneNumber}]}) of
     {ok, {{_, 200, _}, _, Body}} -> {ok, {Data}} = json:decode(Body), {ok, Data};
@@ -23,7 +23,7 @@ update_voice_url(Channel, PhoneNumber) ->
     {ok, PhoneSid} ->
       AccountSid = channel:account_sid(Channel),
       AuthToken = channel:auth_token(Channel),
-      RequestUrl = verboice_config:twilio_base_url() ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
+      RequestUrl = channel:base_url(Channel) ++ "/Accounts/" ++ AccountSid ++ "/IncomingPhoneNumbers/" ++ binary_to_list(PhoneSid) ++ ".json",
       TwilioCallbackUrl = verboice_config:twilio_callback_url(),
       RequestBody = [{'VoiceUrl', list_to_binary(TwilioCallbackUrl)}],
       uri:post_form(RequestBody, [{basic_auth, {AccountSid, AuthToken}}], RequestUrl),

--- a/broker/src/twilio/twilio_broker.erl
+++ b/broker/src/twilio/twilio_broker.erl
@@ -28,7 +28,7 @@ dispatch(_Session = #session{session_id = SessionId, channel = Channel, address 
   CallbackUrl = verboice_config:twilio_callback_url(),
   CallbackUri = uri:parse(CallbackUrl),
 
-  RequestUrl = [verboice_config:twilio_base_url() ++ "/Accounts/", AccountSid, "/Calls"],
+  RequestUrl = [channel:base_url(Channel) ++ "/Accounts/", AccountSid, "/Calls"],
   RequestBody = [
     {'From', util:normalize_phone_number(channel:number(Channel))},
     {'To', util:normalize_phone_number(Address)},

--- a/broker/src/twilio/twilio_broker.erl
+++ b/broker/src/twilio/twilio_broker.erl
@@ -28,7 +28,7 @@ dispatch(_Session = #session{session_id = SessionId, channel = Channel, address 
   CallbackUrl = verboice_config:twilio_callback_url(),
   CallbackUri = uri:parse(CallbackUrl),
 
-  RequestUrl = ["https://api.twilio.com/2010-04-01/Accounts/", AccountSid, "/Calls"],
+  RequestUrl = [verboice_config:twilio_base_url() ++ "/Accounts/", AccountSid, "/Calls"],
   RequestBody = [
     {'From', util:normalize_phone_number(channel:number(Channel))},
     {'To', util:normalize_phone_number(Address)},

--- a/broker/src/verboice_config.erl
+++ b/broker/src/verboice_config.erl
@@ -31,6 +31,7 @@ load_config() ->
   load(guisso_url, string),
   load(broker_httpd_base_url,string),
   load(twilio_callback_url, string),
+  load(twilio_base_url, string),
   load(hub_enabled, bool),
   load(hub_url, string),
   ok.

--- a/broker/verboice.config
+++ b/broker/verboice.config
@@ -32,6 +32,7 @@
     {guisso_url, ""},
 
     {twilio_callback_url, "http://localhost:8080/"},
+    {twilio_base_url, "https://api.twilio.com/2010-04-01"},
 
     {hub_enabled, false},
     {hub_url, ""}

--- a/broker/verboice.config.no-es
+++ b/broker/verboice.config.no-es
@@ -27,6 +27,7 @@
     {guisso_url, ""},
 
     {twilio_callback_url, "http://localhost:8080/"},
+    {twilio_base_url, "https://api.twilio.com/2010-04-01"},
 
     {hub_enabled, true},
     {hub_url, ""}


### PR DESCRIPTION
Pending:

- [ ] Test the whole feature locally using Twilio Edge Locations endpoints

---

This is how it looks (including validation message):

![Twilio Channel (Verboice)](https://user-images.githubusercontent.com/39921597/96728342-67092800-138a-11eb-83cb-043862e0f714.png)

![Twilio Channel (Surveda)](https://user-images.githubusercontent.com/39921597/96728928-fa425d80-138a-11eb-8729-471c843bdd67.png)

Fix #878