### PR TITLE
Cleanup expired Let's Encrypt CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.3.8
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 # Install dependencies
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM ruby:2.3.8
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 # Install dependencies
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -4,6 +4,9 @@ FROM erlang:17.5.6
 # (removes reference to jessie-updates repository)
 RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
 
+# # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 # Install dependencies
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y libzmq3-dev sox libsox-fmt-mp3 festival postfix curl ruby && \


### PR DESCRIPTION
Let's Encrypt old Certificate Authority expired on Sept 30, 2021.

Most of InSTEDD's infra uses those certificates, so this patch makes new certificates work again.