### PR TITLE
Improve logs and ensure update

### DIFF
--- a/broker/src/session/session.erl
+++ b/broker/src/session/session.erl
@@ -496,7 +496,7 @@ finalize({failed, Reason}, State = #state{session = Session = #session{call_log 
     {internal_error, Details} -> [{fail_reason, "internal error"}, {fail_details, io_lib:format("~p", [Details])}];
     _ ->                         [{fail_reason, "unknown error"}]
   end,
-  CallLog:update([{state, NewState}, {finished_at, calendar:universal_time()}] ++ FailInfo),
+  ok = CallLog:update([{state, NewState}, {finished_at, calendar:universal_time()}] ++ FailInfo),
   StopReason = case Reason of
     {error, ErrDetails2} -> ErrDetails2;
     {error, ErrDetails2, _} -> ErrDetails2;

--- a/broker/src/session/session.erl
+++ b/broker/src/session/session.erl
@@ -485,7 +485,7 @@ finalize({failed, Reason}, State = #state{session = Session = #session{call_log 
           "queued"
       end
   end,
-  lager:info("Call failed with reason ~p", [Reason]),
+  lager:info("Call failed with reason ~p and new state ~p", [Reason, NewState]),
   FailInfo = case Reason of
     hangup ->                    [{fail_reason, "hangup"}];
     busy ->                      [{fail_reason, "busy"}];


### PR DESCRIPTION
Sadly, this PR doesn't solve #900, but I expect it will help us to find a solution in the future.

Everything seems to point to the call state being properly updated to a different state than `active` when the call fails. I was able to reproduce a very similar error, obtaining very similar logs, but without reproducing the described effect.

With these changes, we'll be even surer that the error is somewhere else. Where? I don't know, but at least in the future, we'll have more certainties and fewer places to look for the bug.

So, I'm sorry I didn't find the bug yet. We'll continue looking for you, little obscure bug!

Below are the mentioned logs, obtained while debugging by adding a `sleep()` of 10 secs [here](https://github.com/instedd/verboice/blob/178b27c540fefd369c7fbec264de86947e731609/broker/src/twilio/twilio_pbx.erl#L141) and reducing the timeout to 5 secs [there](https://github.com/instedd/verboice/blob/178b27c540fefd369c7fbec264de86947e731609/broker/src/twilio/twilio_pbx.erl#L50):

```
18:28:23.062 [info] [<0.678.0>|693f9ece] session: Start
18:28:28.117 [error] [<0.678.0>|7c752752] session: Error during session "34ff7c3c-2a60-42ef-b925-563660501091": exit:{timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}}
18:28:28.153 [info] [<0.661.0>|f99f6a8d] session: Call failed with reason {internal_error,{timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}}} and new state failed
18:28:28.153 [warning] [<0.661.0>|f99f6a8d] session: Session ("34ff7c3c-2a60-42ef-b925-563660501091") terminated with reason: {timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}}
18:28:28.153 [error] [<0.661.0>|undefined] unknown_module: gen_fsm {session,[51,52,102,102,55,99,51,99,45,50,97,54,48,45,52,50,101,102,45,98,57,50,53,45,53,54,51,54,54,48,53,48,49,48,57,49]} in state in_progress terminated with reason: {timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}}
18:28:28.154 [error] [<0.661.0>|undefined] unknown_module: CRASH REPORT Process <0.661.0> with 0 neighbours exited with reason: {timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}} in gen_fsm:terminate/7 line 611 
18:28:28.156 [error] [<0.145.0>|undefined] unknown_module: Supervisor session_sup had child "34ff7c3c-2a60-42ef-b925-563660501091" started with {session,start_link,undefined} at <0.661.0> exit with reason {timeout,{gen_server,call,[<0.677.0>,{capture,{text,"en",<<"Foo">>},5,"#",1,1},5000]}} in context child_terminated
```

Thanks, @ysbaddaden for your brilliant analysis. It helped me a lot. Indeed, this PR tries to help answer your question:

> Maybe the CallLog state is incorrectly updated in `session:finalize` ?

I don't think so. But I expect these changes will help us to answer your question better in the future.