### PR TITLE
Garbage collector for active calls

### DIFF
--- a/app/controllers/api/calls_controller.rb
+++ b/app/controllers/api/calls_controller.rb
@@ -95,12 +95,6 @@ module Api
       call_log = current_account.call_logs.where(:id => params[:id]).first
       return head :not_found if call_log.nil?
 
-      queued_calls = QueuedCall.where(call_log_id: call_log.id).all
-      queued_calls.each do |qc|
-        qc.cancel_call!
-        qc.destroy
-      end
-
       call_log.state = "cancelled"
       call_log.save!
 

--- a/app/controllers/api/calls_controller.rb
+++ b/app/controllers/api/calls_controller.rb
@@ -95,6 +95,12 @@ module Api
       call_log = current_account.call_logs.where(:id => params[:id]).first
       return head :not_found if call_log.nil?
 
+      queued_calls = QueuedCall.where(call_log_id: call_log.id).all
+      queued_calls.each do |qc|
+        qc.cancel_call!
+        qc.destroy
+      end
+
       call_log.state = "cancelled"
       call_log.save!
 

--- a/app/controllers/api/calls_controller.rb
+++ b/app/controllers/api/calls_controller.rb
@@ -97,7 +97,6 @@ module Api
 
       queued_calls = QueuedCall.where(call_log_id: call_log.id).all
       queued_calls.each do |qc|
-        qc.cancel_call!
         qc.destroy
       end
 

--- a/broker/include/config_methods.hrl
+++ b/broker/include/config_methods.hrl
@@ -11,6 +11,7 @@
 ?METHOD_TPL(record_dir).
 ?METHOD_TPL(seconds_between_calls).
 ?METHOD_TPL(seconds_for_call_back).
+?METHOD_TPL(minutes_for_cancelling_active_calls).
 ?METHOD_TPL(db_name).
 ?METHOD_TPL(db_user).
 ?METHOD_TPL(db_pass).

--- a/broker/include/config_methods.hrl
+++ b/broker/include/config_methods.hrl
@@ -11,6 +11,7 @@
 ?METHOD_TPL(record_dir).
 ?METHOD_TPL(seconds_between_calls).
 ?METHOD_TPL(seconds_for_call_back).
+?METHOD_TPL(minutes_between_active_calls_gc_runs).
 ?METHOD_TPL(minutes_for_cancelling_active_calls).
 ?METHOD_TPL(db_name).
 ?METHOD_TPL(db_user).

--- a/broker/src/models/call_log.erl
+++ b/broker/src/models/call_log.erl
@@ -1,5 +1,5 @@
 -module(call_log).
--export([error/3, info/3, trace/3]).
+-export([error/3, info/3, trace/3, cancel_active_calls_for_minutes/2]).
 -define(TABLE_NAME, "call_logs").
 -include_lib("erl_dbmodel/include/model.hrl").
 
@@ -12,3 +12,6 @@ info(Message, Details, #call_log{id = CallId}) ->
 trace(Message, Details, #call_log{id = CallId}) ->
   call_log_entry:create("trace", CallId, Message, Details).
 
+cancel_active_calls_for_minutes(N, Reason) ->
+  N_Minutes_Ago = util:seconds_ago(N * 60),
+  call_log:update_all([{state, "failed"}, {fail_reason, Reason}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]).

--- a/broker/src/models/call_log.erl
+++ b/broker/src/models/call_log.erl
@@ -14,4 +14,6 @@ trace(Message, Details, #call_log{id = CallId}) ->
 
 cancel_active_calls_for_minutes(N, Reason) ->
   N_Minutes_Ago = util:seconds_ago(N * 60),
-  call_log:update_all([{state, "failed"}, {fail_reason, Reason}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]).
+  Count = call_log:update_all([{state, "failed"}, {fail_reason, Reason}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]),
+  true = is_number(Count) and (Count > -1),
+  Count.

--- a/broker/src/models/call_log.erl
+++ b/broker/src/models/call_log.erl
@@ -1,5 +1,5 @@
 -module(call_log).
--export([error/3, info/3, trace/3, cancel_active_calls_for_minutes/1]).
+-export([error/3, info/3, trace/3, cancel_active_calls_started_before/1]).
 -define(TABLE_NAME, "call_logs").
 -include_lib("erl_dbmodel/include/model.hrl").
 
@@ -12,8 +12,7 @@ info(Message, Details, #call_log{id = CallId}) ->
 trace(Message, Details, #call_log{id = CallId}) ->
   call_log_entry:create("trace", CallId, Message, Details).
 
-cancel_active_calls_for_minutes(N) ->
-  N_Minutes_Ago = util:seconds_ago(N * 60),
-  Count = call_log:update_all([{state, "failed"}, {fail_reason, "active-for-too-long"}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]),
+cancel_active_calls_started_before(StartedAt) ->
+  Count = call_log:update_all([{state, "failed"}, {fail_reason, "active-for-too-long"}], [{state, "active"}, {started_at, '<', StartedAt}]),
   true = is_number(Count) and (Count > -1),
   Count.

--- a/broker/src/models/call_log.erl
+++ b/broker/src/models/call_log.erl
@@ -1,5 +1,5 @@
 -module(call_log).
--export([error/3, info/3, trace/3, cancel_active_calls_for_minutes/2]).
+-export([error/3, info/3, trace/3, cancel_active_calls_for_minutes/1]).
 -define(TABLE_NAME, "call_logs").
 -include_lib("erl_dbmodel/include/model.hrl").
 
@@ -12,8 +12,8 @@ info(Message, Details, #call_log{id = CallId}) ->
 trace(Message, Details, #call_log{id = CallId}) ->
   call_log_entry:create("trace", CallId, Message, Details).
 
-cancel_active_calls_for_minutes(N, Reason) ->
+cancel_active_calls_for_minutes(N) ->
   N_Minutes_Ago = util:seconds_ago(N * 60),
-  Count = call_log:update_all([{state, "failed"}, {fail_reason, Reason}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]),
+  Count = call_log:update_all([{state, "failed"}, {fail_reason, "active-for-too-long"}], [{state, "active"}, {started_at, '<', N_Minutes_Ago}]),
   true = is_number(Count) and (Count > -1),
   Count.

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -1,0 +1,44 @@
+% Active calls GC: Garbage collector for active calls.
+% When a call remains active for too long Verboice considers there was an error and cancels it.
+% This GC runs every INTERVAL. It cancels every active call for N (default=120) minutes.
+% This time (N) is configurable via the ENV variable minutes_for_cancelling_active_calls.
+-module(active_calls_gc).
+-export([start_link/0]).
+
+-behaviour(gen_server).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+-define(ONE_MINUTE, 60000).
+-define(TEN_MINUTES, 600000).
+
+-define(INIT_DELAY, ?ONE_MINUTE).
+-define(INTERVAL, ?TEN_MINUTES).
+
+start_link() ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, {}, []).
+
+init({}) ->
+  erlang:send_after(?INIT_DELAY,self(),cancel_active_calls),
+  {ok, undefined}.
+
+handle_call(_Request, _From, State) ->
+  {reply, {error, unknown_call}, State}.
+
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+
+handle_info(cancel_active_calls, State) ->
+  % TODO: Do it!
+  erlang:send_after(?INTERVAL,self(),cancel_active_calls),
+  {noreply, State};
+
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -1,8 +1,8 @@
 % Active calls GC: Garbage collector for active calls.
 % When a call remains active for too long Verboice considers there was an error and cancels it.
 % This GC runs every X minutes and cancels every active call for more than N minutes.
-% The value X defaults to 10 minutes and is configurable through via the environment variable `minutes_between_active_calls_gc_runs`.
-% The value N defaults to 120 minutes and is configurable through the environment variable `minutes_for_cancelling_active_calls`.-module(active_calls_gc).
+% The value X defaults to 10 minutes and is configurable via the ENV variable `minutes_between_active_calls_gc_runs`.
+% The value N defaults to 120 minutes and is configurable via the ENV variable `minutes_for_cancelling_active_calls`.
 -module(active_calls_gc).
 -export([code_change/3, handle_call/3, handle_cast/2, handle_info/2, init/1, start_link/0, terminate/2]).
 -compile([{parse_transform, lager_transform}]).

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -10,14 +10,12 @@
 
 -define(SERVER, ?MODULE).
 
--define(MILLISECS_IN_ONE_MINUTE, 60000).
--define(INIT_DELAY, ?MILLISECS_IN_ONE_MINUTE).
-
 start_link() ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, {}, []).
 
 init({}) ->
-  erlang:send_after(?INIT_DELAY,self(),cancel_active_calls),
+  Interval = verboice_config:minutes_between_active_calls_gc_runs(),
+  timer:send_interval(timer:minutes(Interval), cancel_active_calls),
   {ok, undefined}.
 
 handle_call(_Request, _From, State) ->
@@ -31,8 +29,6 @@ handle_info(cancel_active_calls, State) ->
   N_Minutes_Ago = util:seconds_ago(N * 60),
   Count = call_log:cancel_active_calls_started_before(N_Minutes_Ago),
   lager:info("GC cancelled ~p calls that stayed active for more than ~p minutes", [Count, N]),
-  Interval = ?MILLISECS_IN_ONE_MINUTE * verboice_config:minutes_between_active_calls_gc_runs(),
-  erlang:send_after(Interval, self(), cancel_active_calls),
   {noreply, State};
 
 handle_info(_Info, State) ->

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -28,7 +28,8 @@ handle_cast(_Msg, State) ->
 
 handle_info(cancel_active_calls, State) ->
   N = verboice_config:minutes_for_cancelling_active_calls(),
-  Count = call_log:cancel_active_calls_for_minutes(N),
+  N_Minutes_Ago = util:seconds_ago(N * 60),
+  Count = call_log:cancel_active_calls_started_before(N_Minutes_Ago),
   lager:info("GC cancelled ~p calls that stayed active for more than ~p minutes", [Count, N]),
   Interval = ?MILLISECS_IN_ONE_MINUTE * verboice_config:minutes_between_active_calls_gc_runs(),
   erlang:send_after(Interval, self(), cancel_active_calls),

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -30,7 +30,9 @@ handle_cast(_Msg, State) ->
   {noreply, State}.
 
 handle_info(cancel_active_calls, State) ->
-  % TODO: Do it!
+  N = verboice_config:minutes_for_cancelling_active_calls(),
+  Reason = "active_calls_gc N=" ++ integer_to_list(N),
+  call_log:cancel_active_calls_for_minutes(N, Reason),
   erlang:send_after(?INTERVAL,self(),cancel_active_calls),
   {noreply, State};
 

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -1,7 +1,8 @@
 % Active calls GC: Garbage collector for active calls.
 % When a call remains active for too long Verboice considers there was an error and cancels it.
-% This GC runs every INTERVAL. It cancels every active call for N (default=120) minutes.
-% This time (N) is configurable via the ENV variable minutes_for_cancelling_active_calls.
+% This GC runs every X minutes and cancels every active call for more than N minutes.
+% The value X defaults to 10 minutes and is configurable through via the environment variable `minutes_between_active_calls_gc_runs`.
+% The value N defaults to 120 minutes and is configurable through the environment variable `minutes_for_cancelling_active_calls`.-module(active_calls_gc).
 -module(active_calls_gc).
 -export([code_change/3, handle_call/3, handle_cast/2, handle_info/2, init/1, start_link/0, terminate/2]).
 -compile([{parse_transform, lager_transform}]).
@@ -9,11 +10,8 @@
 
 -define(SERVER, ?MODULE).
 
--define(ONE_MINUTE, 60000).
--define(TEN_MINUTES, 600000).
-
--define(INIT_DELAY, ?ONE_MINUTE).
--define(INTERVAL, ?TEN_MINUTES).
+-define(MILLISECS_IN_ONE_MINUTE, 60000).
+-define(INIT_DELAY, ?MILLISECS_IN_ONE_MINUTE).
 
 start_link() ->
   gen_server:start_link({local, ?SERVER}, ?MODULE, {}, []).
@@ -32,7 +30,8 @@ handle_info(cancel_active_calls, State) ->
   N = verboice_config:minutes_for_cancelling_active_calls(),
   Count = call_log:cancel_active_calls_for_minutes(N),
   lager:info("GC cancelled ~p calls that stayed active for more than ~p minutes", [Count, N]),
-  erlang:send_after(?INTERVAL,self(),cancel_active_calls),
+  Interval = ?MILLISECS_IN_ONE_MINUTE * verboice_config:minutes_between_active_calls_gc_runs(),
+  erlang:send_after(Interval, self(), cancel_active_calls),
   {noreply, State};
 
 handle_info(_Info, State) ->

--- a/broker/src/scheduler/active_calls_gc.erl
+++ b/broker/src/scheduler/active_calls_gc.erl
@@ -30,9 +30,8 @@ handle_cast(_Msg, State) ->
 
 handle_info(cancel_active_calls, State) ->
   N = verboice_config:minutes_for_cancelling_active_calls(),
-  Reason = "active_calls_gc N=" ++ integer_to_list(N),
-  Count = call_log:cancel_active_calls_for_minutes(N, Reason),
-  lager:info("Active calls GC run with N=~p and Count=~p", [N, Count]),
+  Count = call_log:cancel_active_calls_for_minutes(N),
+  lager:info("GC cancelled ~p calls that stayed active for more than ~p minutes", [Count, N]),
   erlang:send_after(?INTERVAL,self(),cancel_active_calls),
   {noreply, State};
 

--- a/broker/src/scheduler/scheduler_sup.erl
+++ b/broker/src/scheduler/scheduler_sup.erl
@@ -15,7 +15,8 @@ init({}) ->
   Children = [
     ?CHILD(channel_mgr, worker),
     ?CHILD(scheduler, worker),
-    ?CHILD(channel_sup, supervisor)
+    ?CHILD(channel_sup, supervisor),
+    ?CHILD(active_calls_gc, worker)
   ],
   RestartStrategy = {one_for_all, 5, 10},
   {ok, {RestartStrategy, Children}}.

--- a/broker/src/util.erl
+++ b/broker/src/util.erl
@@ -1,5 +1,5 @@
 -module(util).
--export([md5hex/1, to_string/1, binary_to_lower_atom/1, strip_nl/1, binary_to_integer/1, parse_qs/1, normalize_phone_number/1, interpolate/2, interpolate_js/2, to_poirot/1, parse_short_time/1, time_from_now/1, deflate/1, as_binary/1]).
+-export([md5hex/1, to_string/1, binary_to_lower_atom/1, strip_nl/1, binary_to_integer/1, parse_qs/1, normalize_phone_number/1, interpolate/2, interpolate_js/2, to_poirot/1, parse_short_time/1, time_from_now/1, seconds_ago/1, deflate/1, as_binary/1]).
 
 md5hex(Data) ->
   Hash = crypto:hash(md5, Data),
@@ -101,6 +101,9 @@ parse_short_time(String) ->
 
 time_from_now(Seconds) ->
   calendar:gregorian_seconds_to_datetime(calendar:datetime_to_gregorian_seconds(calendar:universal_time()) + Seconds).
+
+seconds_ago(N) ->
+  calendar:gregorian_seconds_to_datetime(calendar:datetime_to_gregorian_seconds(calendar:universal_time()) - N).
 
 deflate(Binary) ->
   Z = zlib:open(),

--- a/broker/src/verboice_config.erl
+++ b/broker/src/verboice_config.erl
@@ -17,6 +17,7 @@ load_config() ->
   load(record_dir, string),
   load(seconds_between_calls, int),
   load(seconds_for_call_back, int),
+  load(minutes_for_cancelling_active_calls, int),
   load(db_name, string),
   load(db_user, string),
   load(db_pass, string),

--- a/broker/src/verboice_config.erl
+++ b/broker/src/verboice_config.erl
@@ -17,6 +17,7 @@ load_config() ->
   load(record_dir, string),
   load(seconds_between_calls, int),
   load(seconds_for_call_back, int),
+  load(minutes_between_active_calls_gc_runs, int),
   load(minutes_for_cancelling_active_calls, int),
   load(db_name, string),
   load(db_user, string),

--- a/broker/test/test_app.erl
+++ b/broker/test/test_app.erl
@@ -21,7 +21,8 @@ start() ->
       {broker_port, 19000},
       {base_url, "http://localhost:3000"},
       {hub_enabled, false},
-      {seconds_between_calls, 2}
+      {seconds_between_calls, 2},
+      {minutes_between_active_calls_gc_runs, 10}
     ]}
   ]}),
 

--- a/broker/verboice.config
+++ b/broker/verboice.config
@@ -14,6 +14,7 @@
 
     {seconds_between_calls, 2},
     {seconds_for_call_back, 15},
+    {minutes_between_active_calls_gc_runs, 10},
     {minutes_for_cancelling_active_calls, 120},
 
     {db_name, "verboice_development"},

--- a/broker/verboice.config
+++ b/broker/verboice.config
@@ -14,6 +14,7 @@
 
     {seconds_between_calls, 2},
     {seconds_for_call_back, 15},
+    {minutes_for_cancelling_active_calls, 120},
 
     {db_name, "verboice_development"},
     {db_user, "root"},

--- a/broker/verboice.config.no-es
+++ b/broker/verboice.config.no-es
@@ -10,6 +10,7 @@
 
     {seconds_between_calls, 8},
     {seconds_for_call_back, 30},
+    {minutes_between_active_calls_gc_runs, 10},
     {minutes_for_cancelling_active_calls, 120},
 
     {db_name, "verboice_development"},

--- a/broker/verboice.config.no-es
+++ b/broker/verboice.config.no-es
@@ -10,6 +10,7 @@
 
     {seconds_between_calls, 8},
     {seconds_for_call_back, 30},
+    {minutes_for_cancelling_active_calls, 120},
 
     {db_name, "verboice_development"},
     {db_user, "root"},

--- a/db/migrate/20220526143259_add_index_to_call_logs_on_state.rb
+++ b/db/migrate/20220526143259_add_index_to_call_logs_on_state.rb
@@ -1,0 +1,5 @@
+class AddIndexToCallLogsOnState < ActiveRecord::Migration
+  def change
+    add_index :call_logs, [:state]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200420225523) do
+ActiveRecord::Schema.define(:version => 20220526143259) do
 
   create_table "accounts", :force => true do |t|
     t.string   "email",                               :default => "", :null => false
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(:version => 20200420225523) do
   add_index "call_logs", ["call_flow_id"], :name => "index_call_logs_on_call_flow_id"
   add_index "call_logs", ["contact_id"], :name => "index_call_logs_on_contact_id"
   add_index "call_logs", ["project_id"], :name => "index_call_logs_on_project_id"
+  add_index "call_logs", ["state"], :name => "index_call_logs_on_state"
 
   create_table "channels", :force => true do |t|
     t.integer  "account_id"


### PR DESCRIPTION
When a call remains active for too long Verboice considers there was an error and cancels it.

This GC runs every X minutes and cancels every active call for more than N minutes.

The value X defaults to 10 minutes and is configurable via the ENV variable `minutes_between_active_calls_gc_runs`.

The value N defaults to 120 minutes and is configurable via the ENV variable `minutes_for_cancelling_active_calls`.

For #900

Bonus track: buggy code deletion.