### PR TITLE
Make asterisk container depend on its bridge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - sounds:/var/lib/asterisk/sounds/verboice
       - verboice-data:/data
     network_mode: host
+    depends_on:
+      - asterisk-bridge
 
   asterisk-bridge:
     image: instedd/host_bridge


### PR DESCRIPTION
Due to networking issues, the Verboice broker won't know an
asterisk channel is up if the asterisk-bridge container is not
running. So there's no scenario in which it makes sense (for
Verboice) to have asterisk running without the bridge running.