### PR TITLE
Fix: Support MySQL's ANSI_QUOTES in hand-written queries

### DIFF
--- a/db/migrate/20200420224723_unify_cancelled_and_cancelled_call_states.rb
+++ b/db/migrate/20200420224723_unify_cancelled_and_cancelled_call_states.rb
@@ -2,8 +2,8 @@ class UnifyCancelledAndCancelledCallStates < ActiveRecord::Migration
   def up
     ActiveRecord::Base.connection.execute <<-SQL
       UPDATE `call_logs`
-      SET `state` = "cancelled"
-      WHERE `state` = "canceled"
+      SET `state` = 'cancelled'
+      WHERE `state` = 'canceled'
     SQL
   end
 

--- a/db/migrate/20200420225523_remove_deprecated_suspended_call_log_state.rb
+++ b/db/migrate/20200420225523_remove_deprecated_suspended_call_log_state.rb
@@ -2,8 +2,8 @@ class RemoveDeprecatedSuspendedCallLogState < ActiveRecord::Migration
   def up
     ActiveRecord::Base.connection.execute <<-SQL
       UPDATE `call_logs`
-      SET `state` = "cancelled", `fail_reason` = "Call was kept in a deprecated 'suspended' state"
-      WHERE `state` = "suspended"
+      SET `state` = 'cancelled', `fail_reason` = 'Call was kept in a deprecated "suspended" state'
+      WHERE `state` = 'suspended'
     SQL
   end
 


### PR DESCRIPTION
When exectuing hand-written queries to the database, use the correct quotes for each type of object.

See instedd/surveda#2140 for more context on the issue