### PR TITLE
Make broker respond 200 OK on root path

### DIFF
--- a/broker/src/africas_talking/africas_talking_httpd_module.erl
+++ b/broker/src/africas_talking/africas_talking_httpd_module.erl
@@ -57,6 +57,5 @@ do(#mod{request_uri = "/africas_talking" ++ _, method = "POST", entity_body = Bo
         end)
   end;
 
-do(ModData) ->
-  io:format("Unhandled: ~p~n", [ModData]),
-  {proceed, [ModData]}.
+do(#mod{data = Data}) ->
+  {proceed, Data}.

--- a/broker/src/healthcheck_httpd_module.erl
+++ b/broker/src/healthcheck_httpd_module.erl
@@ -1,0 +1,12 @@
+-module(healthcheck_httpd_module).
+-export([do/1]).
+
+-include_lib("inets/include/httpd.hrl").
+-include("db.hrl").
+-compile([{parse_transform, lager_transform}]).
+
+do(#mod{request_uri = "/", method = "GET", entity_body = _, data = _}) ->
+  {proceed, [{response, {200, "OK"}}]};
+
+do(#mod{data = Data}) ->
+  {proceed, Data}.

--- a/broker/verboice.config
+++ b/broker/verboice.config
@@ -67,7 +67,7 @@
         {server_root, "."},
         {document_root, "tmp/www"},
         {port, 8080},
-        {modules, [africas_talking_httpd_module, twilio_httpd_module, mod_get, mod_log]},
+        {modules, [africas_talking_httpd_module, twilio_httpd_module, healthcheck_httpd_module, mod_get, mod_log]},
         {transfer_log, "log/httpd.log"},
         {error_log, "log/httpd_error.log"}
       ]}


### PR DESCRIPTION
Whenever the broker gets a 'GET /' request, respond an HTTP 200 OK instead of an error.

This helps healthchecks to succeed.