### PR TITLE
Check status messages to don't be nil in channel index

### DIFF
--- a/app/views/channels/index.haml
+++ b/app/views/channels/index.haml
@@ -29,10 +29,11 @@
               &mdash; disabled
             - unless status_ok
               %br
-              - status[:messages].each do |message|
-                %label.error
-                  = message
-                %br
+              - if status[:messages]
+                - status[:messages].each do |message|
+                  %label.error
+                    = message
+                  %br
           %td
             %button.farrow{:type => :button}
     %tr


### PR DESCRIPTION
Small fix to work properly with the Twilio simulator.

