### PR TITLE
Fix: Debian Stretch archived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
 
       - name: Set environment up
         run: |
-          docker-compose pull
-          docker-compose build
-          docker-compose run --rm broker sh -c './rebar get-deps'
-          docker-compose run --rm broker sh -c './rebar compile'
-          docker-compose run --rm web bundle install
-          docker-compose run --rm web rake db:setup
-          docker-compose run --rm web rake db:test:prepare
+          docker compose pull
+          docker compose build
+          docker compose run --rm broker sh -c './rebar get-deps'
+          docker compose run --rm broker sh -c './rebar compile'
+          docker compose run --rm web bundle install
+          docker compose run --rm web rake db:setup
+          docker compose run --rm web rake db:test:prepare
 
       - name: Run specs
         run: |
-          docker-compose run --rm web rspec
-          docker-compose run --rm broker make eunit
+          docker compose run --rm web rspec
+          docker compose run --rm broker make eunit
 
   build:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set environment up
         run: |
@@ -31,6 +31,6 @@ jobs:
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
       DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build image & push to Docker Hub
         run: ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ruby:2.3.8
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 # Install dependencies
 RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,6 +3,9 @@ FROM ruby:2.3.8
 # Cleanup expired Let's Encrypt CA (Sept 30, 2021)
 RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 # Install dependencies
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ We use [`dockerdev`](https://github.com/waj/dockerdev) to get domain names for t
 Run the following commands to have a stable development environment.
 
 ```
-$ docker-compose run --rm --no-deps web bundle install
-$ docker-compose run --rm web bash
+$ docker compose run --rm --no-deps web bundle install
+$ docker compose run --rm web bash
 root@web_1 $ rake db:setup db:seed
-$ docker-compose up
+$ docker compose up
 ```
 
 You can also run the frontend unit tests inside the docker container. Here's how:
 
 ```
-$ docker-compose run --rm web rake db:test:prepare
-$ docker-compose run --rm web rspec
+$ docker compose run --rm web rake db:test:prepare
+$ docker compose run --rm web rspec
 ```
 
 Testing with Zeus

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,14 +1,9 @@
-#!/bin/sh
-docker-compose build
+#!/bin/sh -e
+docker compose build
 
-# The next two commands occasionally fail. If so, replace them with:
-# docker-compose run --rm broker bash
-#   ./rebar get-deps
-#   ./rebar compile
-docker-compose run --rm broker ./rebar get-deps
-docker-compose run --rm broker ./rebar compile
+docker compose run --rm broker sh -c './rebar get-deps && ./rebar compile'
 
-docker-compose run --rm web bundle install
-docker-compose run --rm web bundle exec rake db:setup
-docker-compose run --rm web bundle exec rake db:test:prepare
-docker-compose run --rm -v `pwd`:/app asterisk /bin/sh -c 'cp /app/etc/asterisk/* /etc/asterisk'
+docker compose run --rm web bundle install
+docker compose run --rm web bundle exec rake db:setup
+docker compose run --rm web bundle exec rake db:test:prepare
+docker compose run --rm -v `pwd`:/app asterisk /bin/sh -c 'cp /app/etc/asterisk/* /etc/asterisk'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2.0'
 services:
   db:
     image: mysql:5.7
+    platform: linux/amd64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
@@ -10,6 +11,7 @@ services:
 
   broker:
     build: ./broker
+    platform: linux/amd64
     command: /bin/sh -c 'make && make run'
     volumes:
       - ./broker:/app
@@ -31,6 +33,7 @@ services:
         ipv4_address: 172.88.0.88
 
   web: &rails
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -51,6 +54,7 @@ services:
 
   asterisk:
     image: instedd/verboice-asterisk
+    platform: linux/amd64
     environment:
       BROKER_HOST: 172.88.0.88
       LOCAL_NET: 172.88.0.0/16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,9 @@ services:
     tmpfs: /app/tmp
     depends_on:
       - db
-    command: rails server -b 0.0.0.0 -p 80
+    command: rails server -b 0.0.0.0 -p 3000
     ports:
-      - 80
+      - 3000
 
   asterisk:
     image: instedd/verboice-asterisk

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -3,7 +3,7 @@ NC='\033[0m'
 GREEN='\033[0;32m'
 
 echo "----==== Running web tests ====----"
-WEB_TESTS="$(docker-compose run --rm web rspec)"
+WEB_TESTS="$(docker compose run --rm web rspec)"
 
 if [ $? -eq 0 ]; then
   echo "${GREEN}OK${NC}";
@@ -12,7 +12,7 @@ else
 fi
 
 echo "----==== Running broker tests ====----"
-BROKER_TESTS="$(docker-compose run --rm broker make eunit)"
+BROKER_TESTS="$(docker compose run --rm broker make eunit)"
 
 if [ $? -eq 0 ]; then
   echo "${GREEN}OK${NC}";


### PR DESCRIPTION
Debian Stretch has been archived, so the Docker images were failing to build.

This PR updates the images' APT sources.

It also upgrades the project to use the `docker compose` v2 plugin, force using x86_64 images, and changes the web's port in development.