### PR TITLE
Optimize curated addresses

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -121,7 +121,8 @@ class ProjectsController < ApplicationController
     # build a hash from contact_id to all his addresses
     # eg. { 1 => ['123','456'], 2 => ['789'] }
     all_contacts = Hash.new { |hash,key| hash[key] = [] }
-    all_contacts = @project.contact_addresses.order(:id).inject(all_contacts) do |contacts, contact_address|
+    addresses_contacts = @project.contact_addresses.where(address: addresses).pluck(:contact_id)
+    all_contacts = @project.contact_addresses.where(contact_id: addresses_contacts).order(:id).inject(all_contacts) do |contacts, contact_address|
       contacts[contact_address.contact_id] << contact_address.address
       contacts
     end


### PR DESCRIPTION
When queueing calls with a specific call flow from the Projects page, we first check we don't call the same Contact twice (ie, if the user pasted two different phones of the same contact at the same time).

If the project's address book grew large, the method is really slow when mapping contact addresses to contacts, because it loads _every_ contact address for the project from the database - and iterating over them. We've seen this method take ~20 seconds with ~365k contacts in a production environment.

This PR changes the method so it only works with the Contacts of the given phone numbers instead of every contact of the project. We now do two queries to the DB instead of a single one, but we query via an index, and significantly reduce the amount of records to work with.

See #944